### PR TITLE
「同じタグのエントリーが来たら上書き」の実装とUT

### DIFF
--- a/Sources/PriorityQueueTTS/PriorityQueue.swift
+++ b/Sources/PriorityQueueTTS/PriorityQueue.swift
@@ -37,6 +37,14 @@ struct PriorityQueue<T: Comparable> {
         heap.append(element)
         siftUp(heap.count - 1)
     }
+    
+    mutating func remove( where filter: (T) -> Bool ) {
+        for i in (0..<heap.count).reversed() {
+            if ( filter(heap[i]) ) {
+                heap.remove(at:i)
+            }
+        }
+    }
 
     mutating func extractMax() -> T? {
         guard !heap.isEmpty else { return nil }

--- a/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
+++ b/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
@@ -107,7 +107,10 @@ class PriorityQueueTTS: NSObject {
         guard processingEntry == nil else { return }
         guard !queue.isEmpty else { return }
         guard let entry = queue.extractMax() else { return }
-        guard Date().timeIntervalSince1970 < entry.expire_at else { return }
+        guard Date().timeIntervalSince1970 < entry.expire_at else {
+            entry.completion?( entry, nil, .Canceled )
+            return
+        }
         processingEntry = entry
         process(entry: entry)
     }
@@ -156,6 +159,10 @@ class PriorityQueueTTS: NSObject {
                 entry.completion?(entry, nil, .Canceled)
             }
             else {
+                if let utterance, speakingRange == nil {
+                    speakingRange = NSRange(location:0, length:utterance.speechString.count)
+                }
+                
                 entry.finish(with: speakingRange)
                 if entry.is_completed() {
                     if let delegate = self.delegate {

--- a/Sources/PriorityQueueTTS/QueueEntry.swift
+++ b/Sources/PriorityQueueTTS/QueueEntry.swift
@@ -23,6 +23,11 @@
 import Foundation
 import AVFoundation
 
+typealias Tag = String
+extension Tag {
+    static let Default :Tag = "default"
+}
+
 // abstract class QueueEntry
 // higher priority first
 // earier created first
@@ -32,7 +37,7 @@ class QueueEntry: Comparable {
             if tokenIndex < _tokens.count {
                 return _tokens[tokenIndex]
             }
-            if _completed {
+            if is_completed() {
                 return _tokens.last
             }
             return nil
@@ -48,16 +53,29 @@ class QueueEntry: Comparable {
     public let priority: SpeechPriority
     public let created_time: TimeInterval
     public let expire_at: TimeInterval
+    public let tag: Tag
     public var completion: ((_ entry: QueueEntry, _ utterance: AVSpeechUtterance?, _ reason: CompletionReason) -> Void)?
     public func is_completed() -> Bool {
-        return _completed
+        return status == .completed
     }
-    internal var _completed: Bool = false
+    enum Status {
+        case working
+        case completed
+        case canceled
+    }
+    internal private (set) var status: Status = .working
+    public func mark_canceled() {
+        status = .canceled
+    }
+    public func mark_completed() {
+        status = .completed
+    }
 
     init(
         token: Token?,
         priority: SpeechPriority,
         timeout_sec: TimeInterval,
+        tag: Tag,
         completion: ((_: QueueEntry, _: AVSpeechUtterance?, _: CompletionReason) -> Void)?
     ) {
         if let token = token {
@@ -66,6 +84,7 @@ class QueueEntry: Comparable {
         self.priority = priority
         self.created_time = Date().timeIntervalSince1970
         self.expire_at = self.created_time + timeout_sec
+        self.tag = tag
         self.completion = completion
     }
 
@@ -73,18 +92,20 @@ class QueueEntry: Comparable {
         pause: Int,
         priority: SpeechPriority = .Normal,
         timeout_sec: TimeInterval = 10.0,
+        tag: Tag = .Default,
         completion: ((_ entry: QueueEntry, _ utteracne: AVSpeechUtterance?, _ reason: CompletionReason) -> Void)? = nil
     ) {
-        self.init(token: Token.Pause(pause), priority: priority, timeout_sec: timeout_sec, completion: completion)
+        self.init(token: Token.Pause(pause), priority: priority, timeout_sec: timeout_sec, tag: tag, completion: completion)
     }
 
     convenience init(
         text: String,
         priority: SpeechPriority = .Normal,
         timeout_sec: TimeInterval = 10.0,
+        tag: Tag = .Default,
         completion: ((_ entry: QueueEntry, _ utteracne: AVSpeechUtterance?, _ reason: CompletionReason) -> Void)? = nil
     ) {
-        self.init(token: Token.Text(text), priority: priority, timeout_sec: timeout_sec, completion: completion)
+        self.init(token: Token.Text(text), priority: priority, timeout_sec: timeout_sec, tag: tag, completion: completion)
     }
 
     func progress(with range: NSRange?) {
@@ -99,11 +120,11 @@ class QueueEntry: Comparable {
         case .Text:
             guard let range = range else { return }
             if _tokens[0].udpate(with: range) == false{
-                _completed = true
+                mark_completed()
             }
             break
         case .Pause:
-            _completed = true
+            mark_completed()
             break
         }
     }

--- a/Sources/PriorityQueueTTS/TokenizerEntry.swift
+++ b/Sources/PriorityQueueTTS/TokenizerEntry.swift
@@ -41,6 +41,7 @@ class TokenizerEntry: QueueEntry {
         separator: String,
         priority: SpeechPriority = .Normal,
         timeout_sec: TimeInterval = 10.0,
+        tag: Tag = .Default,
         completion: ((_ entry: QueueEntry, _ reason: CompletionReason) -> Void)? = nil
     ) {
         self.separator = separator
@@ -49,7 +50,7 @@ class TokenizerEntry: QueueEntry {
         self.startIndex = _buffer.startIndex
         self.closed = false
         self._completion = completion
-        super.init(token: nil, priority: priority, timeout_sec: timeout_sec, completion: nil)
+        super.init(token: nil, priority: priority, timeout_sec: timeout_sec, tag: tag, completion: nil)
         self.completion = { entry, utterance, reason in
             switch(reason) {
             case .Canceled:
@@ -122,7 +123,7 @@ class TokenizerEntry: QueueEntry {
         }
         if closed {
             if _tokens.count <= tokenIndex {
-                _completed = true
+                mark_completed()
             }
         }
     }

--- a/Sources/PriorityQueueTTS/TokenizerEntry.swift
+++ b/Sources/PriorityQueueTTS/TokenizerEntry.swift
@@ -53,12 +53,10 @@ class TokenizerEntry: QueueEntry {
         super.init(token: nil, priority: priority, timeout_sec: timeout_sec, tag: tag, completion: nil)
         self.completion = { entry, utterance, reason in
             switch(reason) {
-            case .Canceled:
-                break
             case .Completed:
                 self.tokenIndex += 1
                 break
-            case .Paused:
+            case .Paused, .Canceled:
                 break
             }
             guard let _completion = self._completion else { return }

--- a/Tests/PriorityQueueTTSTests/PriorityQueueTTSTests.swift
+++ b/Tests/PriorityQueueTTSTests/PriorityQueueTTSTests.swift
@@ -392,6 +392,26 @@ final class PriorityQueueTTSTests: XCTestCase {
         <<  (TAG:"A", .Normal)
      */
     func test_10_tag_empty() throws {
+        let expectation = self.expectation(description: "Wait for 30 seconds")
+        let tts = PriorityQueueTTS()
+        var step : Int = 0;
+        tts.start()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            // <<  (TAG:"A", .Normal)
+            let entry1 = QueueEntry(text:self.sample, priority: .Normal, timeout_sec: 30, tag: "A") { item, _, reason in
+                switch(reason) {
+                case .Completed:
+                    XCTAssertEqual( 0, step.pass() )
+                    expectation.fulfill()
+                default:
+                    XCTFail()
+                }
+            }
+            tts.append(entry:entry1, withRemoving:SameTag)
+        }
+        
+        waitForExpectations(timeout: 30, handler: nil)
     }
 
     /*  [
@@ -400,6 +420,37 @@ final class PriorityQueueTTSTests: XCTestCase {
         <<  (TAG:"A", .Normal)
      */
     func test_11_tag_same_levels_no_remove() throws {
+        let expectation = self.expectation(description: "Wait for 30 seconds")
+        let tts = PriorityQueueTTS()
+        var step : Int = 0;
+
+        // 1) (TAG:"Def", .Normal) // keep
+        let entry1 = QueueEntry(text: sample, priority: .Normal, timeout_sec: 30 ) { item, _, reason in
+            switch(reason) {
+            case .Completed:
+                XCTAssertEqual( 0, step.pass() )
+            default:
+                XCTFail()
+            }
+        }
+        tts.append(entry:entry1)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            // <<   (TAG:"A", .Normal)
+            let entry2 = QueueEntry(text:"entry2: (TAG:A, .Normal)", priority: .Normal, timeout_sec: 30, tag: "A") { item, _, reason in
+                switch(reason) {
+                case .Completed:
+                    XCTAssertEqual( 1, step.pass() )
+                    expectation.fulfill()
+                default:
+                    XCTFail()
+                }
+            }
+            tts.append(entry:entry2, withRemoving:SameTag)
+        }
+        
+        tts.start()
+        waitForExpectations(timeout: 30, handler: nil)
     }
 
     /*  [
@@ -409,6 +460,48 @@ final class PriorityQueueTTSTests: XCTestCase {
         <<  (TAG:"A", .Normal)
      */
     func test_12_tag_no_remove() throws {
+        let expectation = self.expectation(description: "Wait for 30 seconds")
+        let tts = PriorityQueueTTS()
+        var step : Int = 0;
+
+        // 1) (TAG:"Def", .Normal) // keep
+        let entry1 = QueueEntry(text: sample, priority: .Normal, timeout_sec: 30 ) { item, _, reason in
+            switch(reason) {
+            case .Completed:
+                XCTAssertEqual( 0, step.pass() )
+            default:
+                XCTFail()
+            }
+        }
+        tts.append(entry:entry1)
+        
+        // 2) (TAG:"Def", .Normal) // keep
+        let entry2 = QueueEntry(text: "entry2: (TAG:Def, .Normal)", priority: .Normal, timeout_sec: 30 ) { item, _, reason in
+            switch(reason) {
+            case .Completed:
+                XCTAssertEqual( 1, step.pass() )
+            default:
+                XCTFail()
+            }
+        }
+        tts.append(entry:entry2)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            // 3) (TAG:"A", .Normal)
+            let entry3 = QueueEntry(text:"entry3: (TAG:A, .Normal)", priority: .Normal, timeout_sec: 30, tag: "A") { item, _, reason in
+                switch(reason) {
+                case .Completed:
+                    XCTAssertEqual( 2, step.pass() )
+                    expectation.fulfill()
+                default:
+                    XCTFail()
+                }
+            }
+            tts.append(entry:entry3, withRemoving:SameTag)
+        }
+        
+        tts.start()
+        waitForExpectations(timeout: 30, handler: nil)
     }
 
     /*  [
@@ -417,6 +510,37 @@ final class PriorityQueueTTSTests: XCTestCase {
         <<  (TAG:"A", .Normal)
      */
     func test_13_tag_replace_1() throws {
+        let expectation = self.expectation(description: "Wait for 30 seconds")
+        let tts = PriorityQueueTTS()
+        var step : Int = 0;
+
+        // 1)  (TAG:"A", .Normal) // stop-replace
+        let entry1 = QueueEntry(text: sample, priority: .Normal, timeout_sec: 30, tag: "A" ) { item, _, reason in
+            switch(reason) {
+            case .Canceled:
+                XCTAssertEqual( 0, step.pass() )
+            default:
+                XCTFail()
+            }
+        }
+        tts.append(entry:entry1)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            // 2) (TAG:"A", .Normal)
+            let entry2 = QueueEntry(text:"entry2: (TAG:A, .Normal)", priority: .Normal, timeout_sec: 30, tag: "A") { item, _, reason in
+                switch(reason) {
+                case .Completed:
+                    XCTAssertEqual( 1, step.pass() )
+                    expectation.fulfill()
+                default:
+                    XCTFail()
+                }
+            }
+            tts.append(entry:entry2, withRemoving:SameTag)
+        }
+        
+        tts.start()
+        waitForExpectations(timeout: 30, handler: nil)
     }
 
     /*  [
@@ -429,16 +553,15 @@ final class PriorityQueueTTSTests: XCTestCase {
     func test_14_tag_replace_all() throws {
         let expectation = self.expectation(description: "Wait for 30 seconds")
         let tts = PriorityQueueTTS()
-        
+        var step : Int = 0;
+
         // 1) (TAG:"A", .Normal) // stop-replace
         let entry1 = QueueEntry(text: sample, priority: .Normal, timeout_sec: 30, tag: "A") { item, _, reason in
             switch(reason) {
-            case .Paused:
-                XCTFail()
-            case .Completed:
-                XCTFail()
             case .Canceled:
-                XCTAssertTrue(true)
+                XCTAssertTrue( (0...2).contains(step.pass()) )
+            default:
+                XCTFail()
             }
         }
         tts.append(entry:entry1)
@@ -446,12 +569,10 @@ final class PriorityQueueTTSTests: XCTestCase {
         // 2) (TAG:"A", .Normal) // remove
         let entry2 = QueueEntry(text:"entry2: (TAG:A, .Normal)", priority: .Normal, timeout_sec: 30, tag: "A") { item, _, reason in
             switch(reason) {
-            case .Paused:
-                XCTFail()
-            case .Completed:
-                XCTFail()
             case .Canceled:
-                XCTAssertTrue(true)
+                XCTAssertTrue( (0...2).contains(step.pass()) )
+            default:
+                XCTFail()
             }
         }
         tts.append(entry:entry2)
@@ -459,12 +580,10 @@ final class PriorityQueueTTSTests: XCTestCase {
         // 3) (TAG:"A", .Normal) // remove
         let entry3 = QueueEntry(text:"entry3 : (TAG:A, .Normal)", priority: .Normal, timeout_sec: 30, tag: "A") { item, _, reason in
             switch(reason) {
-            case .Paused:
-                XCTFail()
-            case .Completed:
-                XCTFail()
             case .Canceled:
-                XCTAssertTrue(true)
+                XCTAssertTrue( (0...2).contains(step.pass()) )
+            default:
+                XCTFail()
             }
         }
         tts.append(entry:entry3)
@@ -473,11 +592,10 @@ final class PriorityQueueTTSTests: XCTestCase {
             // <<  <<  (TAG:"A", .Normal)
             let entry4 = QueueEntry(text:"entry4 : (TAG:A, .Normal)", priority: .Required, timeout_sec: 30, tag: "A") { item, _, reason in
                 switch(reason) {
-                case .Paused:
-                    XCTFail()
                 case .Completed:
+                    XCTAssertEqual( 3, step.pass() )
                     expectation.fulfill()
-                case .Canceled:
+                default:
                     XCTFail()
                 }
             }
@@ -485,7 +603,6 @@ final class PriorityQueueTTSTests: XCTestCase {
         }
         tts.start()
         waitForExpectations(timeout: 30, handler: nil)
-
     }
 
     /*  [
@@ -494,6 +611,37 @@ final class PriorityQueueTTSTests: XCTestCase {
         <<  (TAG:"A", .High)
      */
     func test_15_tag_replace_1() throws {
+        let expectation = self.expectation(description: "Wait for 30 seconds")
+        let tts = PriorityQueueTTS()
+        var step : Int = 0;
+
+        // 1) (TAG:"A", .Normal) // stop-replace
+        let entry1 = QueueEntry(text: sample, priority: .Normal, timeout_sec: 30, tag: "A" ) { item, _, reason in
+            switch(reason) {
+            case .Canceled:
+                XCTAssertEqual( 0, step.pass() )
+            default:
+                XCTFail()
+            }
+        }
+        tts.append(entry:entry1)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            // 2) (TAG:"A", .High)
+            let entry2 = QueueEntry(text:"entry2: (TAG:A, .High)", priority: .High, timeout_sec: 30, tag: "A") { item, _, reason in
+                switch(reason) {
+                case .Completed:
+                    XCTAssertEqual( 1, step.pass() )
+                    expectation.fulfill()
+                default:
+                    XCTFail()
+                }
+            }
+            tts.append(entry:entry2, withRemoving:SameTag)
+        }
+        
+        tts.start()
+        waitForExpectations(timeout: 30, handler: nil)
     }
 
     /*  [
@@ -502,6 +650,37 @@ final class PriorityQueueTTSTests: XCTestCase {
         <<  (TAG:"A", .Normal)
      */
     func test_16_tag_regardless_priority() throws {
+        let expectation = self.expectation(description: "Wait for 30 seconds")
+        let tts = PriorityQueueTTS()
+        var step : Int = 0;
+
+        // 1) (TAG:"A", .High) // stop-replace
+        let entry1 = QueueEntry(text: sample, priority: .High, timeout_sec: 30, tag: "A" ) { item, _, reason in
+            switch(reason) {
+            case .Canceled:
+                XCTAssertEqual( 0, step.pass() )
+            default:
+                XCTFail()
+            }
+        }
+        tts.append(entry:entry1)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            // 2) (TAG:"A", .Normal)
+            let entry2 = QueueEntry(text:"entry2: (TAG:A, .Normal)", priority: .Normal, timeout_sec: 30, tag: "A") { item, _, reason in
+                switch(reason) {
+                case .Completed:
+                    XCTAssertEqual( 1, step.pass() )
+                    expectation.fulfill()
+                default:
+                    XCTFail()
+                }
+            }
+            tts.append(entry:entry2, withRemoving:SameTag)
+        }
+        
+        tts.start()
+        waitForExpectations(timeout: 30, handler: nil)
     }
     
     /*  [
@@ -511,6 +690,48 @@ final class PriorityQueueTTSTests: XCTestCase {
         <<  (TAG:"A", .High)
      */
     func test_17_tag() throws {
+        let expectation = self.expectation(description: "Wait for 30 seconds")
+        let tts = PriorityQueueTTS()
+        var step : Int = 0;
+
+        // 1) (TAG:"A", .High) // stop-replace
+        let entry1 = QueueEntry(text: sample, priority: .High, timeout_sec: 30, tag: "A" ) { item, _, reason in
+            switch(reason) {
+            case .Canceled:
+                XCTAssertEqual( 0, step.pass() )
+            default:
+                XCTFail()
+            }
+        }
+        tts.append(entry:entry1)
+
+        // 2) (TAG:"Def", .Normal) // keep
+        let entry2 = QueueEntry(text: "entry2: (TAG:Def, .Normal)", priority: .Normal, timeout_sec: 30 ) { item, _, reason in
+            switch(reason) {
+            case .Completed:
+                XCTAssertEqual( 2, step.pass() )
+                expectation.fulfill()
+            default:
+                XCTFail()
+            }
+        }
+        tts.append(entry:entry2)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            // 3) (TAG:"A", .High)
+            let entry3 = QueueEntry(text:"entry3: (TAG:A, .High)", priority: .High, timeout_sec: 30, tag: "A") { item, _, reason in
+                switch(reason) {
+                case .Completed:
+                    XCTAssertEqual( 1, step.pass() )
+                default:
+                    XCTFail()
+                }
+            }
+            tts.append(entry:entry3, withRemoving:SameTag)
+        }
+        
+        tts.start()
+        waitForExpectations(timeout: 30, handler: nil)
     }
     
     /*  [
@@ -520,6 +741,48 @@ final class PriorityQueueTTSTests: XCTestCase {
         <<  (TAG:"A", .High)
      */
     func test_18_tag() throws {
+        let expectation = self.expectation(description: "Wait for 30 seconds")
+        let tts = PriorityQueueTTS()
+        var step : Int = 0;
+
+        // 1) (TAG:"Def", .High) // keep
+        let entry1 = QueueEntry(text: sample, priority: .High, timeout_sec: 30 ) { item, _, reason in
+            switch(reason) {
+            case .Completed:
+                XCTAssertEqual( 1, step.pass() )
+            default:
+                XCTFail()
+            }
+        }
+        tts.append(entry:entry1)
+
+        // 2) (TAG:"A", .Normal) // remove
+        let entry2 = QueueEntry(text: "entry2: (TAG:A, .Normal)", priority: .Normal, timeout_sec: 30, tag: "A" ) { item, _, reason in
+            switch(reason) {
+            case .Canceled:
+                XCTAssertEqual( 0, step.pass() )
+            default:
+                XCTFail()
+            }
+        }
+        tts.append(entry:entry2)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            // 3) (TAG:"A", .High)
+            let entry3 = QueueEntry(text:"entry3: (TAG:A, .High)", priority: .High, timeout_sec: 30, tag: "A") { item, _, reason in
+                switch(reason) {
+                case .Completed:
+                    XCTAssertEqual( 2, step.pass() )
+                    expectation.fulfill()
+                default:
+                    XCTFail()
+                }
+            }
+            tts.append(entry:entry3, withRemoving:SameTag)
+        }
+        
+        tts.start()
+        waitForExpectations(timeout: 30, handler: nil)
     }
     
     /*  [
@@ -550,12 +813,10 @@ final class PriorityQueueTTSTests: XCTestCase {
         // 2) (TAG:"A", .Normal) // remove
         let entry2 = QueueEntry(text:"entry2 : (TAG:A, .Normal)", priority: .Normal, timeout_sec: 30, tag: "A") { item, _, reason in
             switch(reason) {
-            case .Paused:
-                XCTFail()
-            case .Completed:
-                XCTFail()
             case .Canceled:
                 XCTAssertTrue(true)
+            default:
+                XCTFail()
             }
         }
         tts.append(entry:entry2)
@@ -564,17 +825,202 @@ final class PriorityQueueTTSTests: XCTestCase {
             // <<  (TAG:"A", .Required)
             let entry3 = QueueEntry(text:"entry3 : (TAG:A, .Required)", priority: .Required, timeout_sec: 30, tag: "A") { item, _, reason in
                 switch(reason) {
-                case .Paused:
-                    XCTFail()
                 case .Completed:
                     XCTAssertEqual( 1, step.pass() )
-                case .Canceled:
+                default:
                     XCTFail()
                 }
             }
             tts.append(entry:entry3, withRemoving:SameTag)
         }
         tts.start()
+        waitForExpectations(timeout: 30, handler: nil)
+    }
+    
+    
+    /*  [
+            (TAG:"A", .Required) // stop-replace
+        ]
+         <<  (TAG:"A", .Required) // stop-replace
+         <<  (TAG:"A", .Required)
+     */
+    func test_20_tag_interrupt_periodically() throws {
+        let expectation = self.expectation(description: "Wait for 30 seconds")
+        let tts = PriorityQueueTTS()
+        var step : Int = 0;
+        
+        // 1) (TAG:"A", .Required) // stop-replace
+        let entry1 = QueueEntry(text: sample, priority: .Required, timeout_sec: 30, tag: "A") { item, _, reason in
+            switch(reason) {
+            case .Canceled:
+                XCTAssertEqual( 0, step.pass() )
+            default:
+                XCTFail()
+            }
+        }
+        tts.append(entry:entry1)
+        tts.start()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            // 2) (TAG:"A", .Required) // stop-replace
+            let entry2 = QueueEntry(text:"entry2 : (TAG:A, .Required)", priority: .Required, timeout_sec: 30, tag: "A") { item, _, reason in
+                switch(reason) {
+                case .Canceled:
+                    XCTAssertEqual( 1, step.pass() )
+                default:
+                    XCTFail()
+                }
+            }
+            tts.append(entry:entry2, withRemoving:SameTag)
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                // << 3) (TAG:"A", .Required)
+                let entry3 = QueueEntry(text:"entry3 : (TAG:A, .Required)", priority: .Required, timeout_sec: 30, tag: "A") { item, _, reason in
+                    switch(reason) {
+                    case .Completed:
+                        XCTAssertEqual( 2, step.pass() )
+                        expectation.fulfill()
+                    default:
+                        XCTFail()
+                    }
+                }
+                tts.append(entry:entry3, withRemoving:SameTag)
+            }
+        }
+        
+        waitForExpectations(timeout: 30, handler: nil)
+    }
+    
+    
+    /*  [
+            (PAUSE  TAG:"A", 30sec) // stop-replace
+        ]
+         <<  (TAG:"A", .Required)
+     */
+    func test_21_tag_stop_pause() throws {
+        let expectation = self.expectation(description: "Wait for 30 seconds")
+        let tts = PriorityQueueTTS()
+        var step : Int = 0;
+        
+        // 1) (PAUSE  TAG:"A", 30sec) // stop-replace
+        let entry1 = QueueEntry( pause: 300, tag: "A") { item, _, reason in
+            switch(reason) {
+            case .Completed:
+                XCTFail()
+            case .Canceled:
+                XCTAssertEqual( 0, step.pass() )
+            default:
+                XCTFail()
+            }
+        }
+        tts.append(entry:entry1)
+        tts.start()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            // 2) (TAG:"A", .Required) // stop-replace
+            let entry2 = QueueEntry(text:"entry2 : (TAG:A, .Required)", priority: .Required, timeout_sec: 30, tag: "A") { item, _, reason in
+                switch(reason) {
+                case .Completed:
+                    XCTAssertEqual( 1, step.pass() )
+                    expectation.fulfill()
+                default:
+                    XCTFail()
+                }
+            }
+            tts.append(entry:entry2, withRemoving:SameTag)
+        }
+
+        waitForExpectations(timeout: 30, handler: nil)
+    }
+    
+    
+    /*  [
+            (TAG:"A", .Normal) // stop-replace
+            (PAUSE  TAG:"A", 30sec, .Normal) // remove
+        ]
+         <<  (TAG:"A", .Normal)
+     */
+    func test_22_tag_remove_contain_pause() throws {
+        let expectation = self.expectation(description: "Wait for 30 seconds")
+        let tts = PriorityQueueTTS()
+        var step : Int = 0;
+        
+        // 1) (TAG:"A", .Normal) // stop-replace
+        let entry1 = QueueEntry(text: sample, priority: .Normal, timeout_sec: 30, tag: "A") { item, _, reason in
+            switch(reason) {
+            case .Canceled:
+                XCTAssertTrue( (0...1).contains(step.pass()) )
+            default:
+                XCTFail()
+            }
+        }
+        tts.append(entry:entry1)
+        
+        // 2) (PAUSE  TAG:"A", 30sec) // stop-replace
+        let entry2 = QueueEntry( pause: 300, priority: .Normal, tag: "A") { item, _, reason in
+            switch(reason) {
+            case .Canceled:
+                XCTAssertTrue( (0...1).contains(step.pass()) )
+            default:
+                XCTFail()
+            }
+        }
+        tts.append(entry:entry2)
+        tts.start()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            // 2) (TAG:"A", .Required) // stop-replace
+            let entry3 = QueueEntry(text:"entry3 : (TAG:A, .Required)", priority: .Required, timeout_sec: 30, tag: "A") { item, _, reason in
+                switch(reason) {
+                case .Completed:
+                    XCTAssertEqual( 2, step.pass() )
+                    expectation.fulfill()
+                default:
+                    XCTFail()
+                }
+            }
+            tts.append(entry:entry3, withRemoving:SameTag)
+        }
+
+        waitForExpectations(timeout: 30, handler: nil)
+    }
+    
+    /*  [
+            (TAG:"A", .Normal) // stop-replace
+        ]
+         <<  (PAUSE  TAG:"A", 3sec, .Normal)
+     */
+    func test_23_tag_cancel_by_pause() throws {
+        let expectation = self.expectation(description: "Wait for 30 seconds")
+        let tts = PriorityQueueTTS()
+        var step : Int = 0;
+        
+        // 1) (TAG:"A", .Normal) // stop-replace
+        let entry1 = QueueEntry(text: sample, priority: .Normal, timeout_sec: 30, tag: "A") { item, _, reason in
+            switch(reason) {
+            case .Canceled:
+                XCTAssertEqual( 0, step.pass() )
+            default:
+                XCTFail()
+            }
+        }
+        tts.append(entry:entry1)
+        tts.start()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            // 2)  (PAUSE  TAG:"A", 3sec, .Normal)
+            let entry2 = QueueEntry( pause: 30, priority: .Normal, tag: "A") { item, _, reason in
+                switch(reason) {
+                case .Completed:
+                    XCTAssertEqual( 1, step.pass() )
+                    expectation.fulfill()
+                default:
+                    XCTFail()
+                }
+            }
+            tts.append(entry:entry2, withRemoving:SameTag)
+        }
+
         waitForExpectations(timeout: 30, handler: nil)
     }
 }

--- a/Tests/PriorityQueueTTSTests/PriorityQueueTTSTests.swift
+++ b/Tests/PriorityQueueTTSTests/PriorityQueueTTSTests.swift
@@ -837,7 +837,6 @@ final class PriorityQueueTTSTests: XCTestCase {
         waitForExpectations(timeout: 30, handler: nil)
     }
     
-    
     /*  [
             (TAG:"A", .Required) // stop-replace
         ]
@@ -891,7 +890,6 @@ final class PriorityQueueTTSTests: XCTestCase {
         waitForExpectations(timeout: 30, handler: nil)
     }
     
-    
     /*  [
             (PAUSE  TAG:"A", 30sec) // stop-replace
         ]
@@ -932,7 +930,6 @@ final class PriorityQueueTTSTests: XCTestCase {
 
         waitForExpectations(timeout: 30, handler: nil)
     }
-    
     
     /*  [
             (TAG:"A", .Normal) // stop-replace
@@ -1023,6 +1020,246 @@ final class PriorityQueueTTSTests: XCTestCase {
 
         waitForExpectations(timeout: 30, handler: nil)
     }
+    
+    /*  [
+            1. (Text timeout: 1s )     // keep
+            2. (Pause: 3s, timeout: 10s ) // keep
+            3. (Pause: 3s, timeout: 1s )  // timeout
+            4. (Text  timeout: 10s )   // keep
+            5. (Text  timeout: 2s )    // timeout
+            6. (Text  timeout: 3s )    // timeout
+            7. (Text  timeout: 20s )   // keep
+        ]
+        
+        wait 1s
+          <<  8. (Text  timeout: 5s )      // timeout
+          <<  9. (Pause: 3s, timeout: 5s ) // timeout
+          << 10. (Text  timeout: 30s )     // keep
+     */
+    func test_24_timeout() throws {
+        let expectation = self.expectation(description: "Wait for 40 seconds")
+        let tts = PriorityQueueTTS()
+        var step : Int = 0;
+        
+        // 1. (Text timeout: 1s )     // keep
+        tts.append(entry: QueueEntry(text:"1. (Text timeout: 1s ) // keep", timeout_sec: 1 ) { item, _, reason in
+            switch(reason) {
+            case .Completed:
+                XCTAssertEqual( 0, step.pass() )
+            default:
+                XCTFail()
+            }
+        })
+        
+        // 2. (Pause: 3s, timeout: 10s ) // keep
+        tts.append(entry: QueueEntry( pause: 30, timeout_sec: 10 ) { item, _, reason in
+            switch(reason) {
+            case .Completed:
+                XCTAssertEqual( 1, step.pass() )
+            default:
+                XCTFail()
+            }
+        })
+
+        // 3. (Pause: 3s, timeout: 1s )  // timeout
+        tts.append(entry: QueueEntry( pause: 30, timeout_sec: 1 ) { item, _, reason in
+            switch(reason) {
+            case .Canceled:
+                XCTAssertEqual( 2, step.pass() )
+            default:
+                XCTFail()
+            }
+        })
+        
+        // 4. (Text  timeout: 10s )   // keep
+        tts.append(entry: QueueEntry(text:"4. (Text  timeout: 10s ) // keep", timeout_sec: 10 ) { item, _, reason in
+            switch(reason) {
+            case .Completed:
+                XCTAssertEqual( 3, step.pass() )
+            default:
+                XCTFail()
+            }
+        })
+        
+        // 5. (Text  timeout: 2s )    // timeout
+        tts.append(entry: QueueEntry(text:"5. (Text  timeout: 2s ) // timeout", timeout_sec: 2 ) { item, _, reason in
+            switch(reason) {
+            case .Canceled:
+                XCTAssertEqual( 4, step.pass() )
+            default:
+                XCTFail()
+            }
+        })
+        
+        // 6. (Text  timeout: 3s )    // timeout
+        tts.append(entry: QueueEntry(text:"6. (Text  timeout: 3s ) // timeout", timeout_sec: 3 ) { item, _, reason in
+            switch(reason) {
+            case .Canceled:
+                XCTAssertEqual( 5, step.pass() )
+            default:
+                XCTFail()
+            }
+        })
+        
+        // 7. (Text  timeout: 20s )   // keep
+        tts.append(entry: QueueEntry(text:"7. (Text  timeout: 20s ) // keep", timeout_sec: 20 ) { item, _, reason in
+            switch(reason) {
+            case .Completed:
+                XCTAssertEqual( 6, step.pass() )
+            default:
+                XCTFail()
+            }
+        })
+
+        tts.start()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            
+            // <<  8. (Text  timeout: 5s )      // timeout
+            tts.append(entry: QueueEntry(text:"<< 8. (Text timeout: 5s ) // timeout", timeout_sec: 5 ) { item, _, reason in
+                switch(reason) {
+                case .Canceled:
+                    XCTAssertEqual( 7, step.pass() )
+                default:
+                    XCTFail()
+                }
+            })
+
+            // <<  9. (Pause: 3s, timeout: 5s ) // timeout
+            tts.append(entry: QueueEntry( pause: 30, timeout_sec: 5 ) { item, _, reason in
+                switch(reason) {
+                case .Canceled:
+                    XCTAssertEqual( 8, step.pass() )
+                default:
+                    XCTFail()
+                }
+            })
+            
+            // 10. (Text  timeout: 30s )     // keep
+            tts.append(entry: QueueEntry(text:"<< 10. (Text timeout: 30s ) // keep", timeout_sec: 30 ) { item, _, reason in
+                switch(reason) {
+                case .Completed:
+                    XCTAssertEqual( 9, step.pass() )
+                    expectation.fulfill()
+                default:
+                    XCTFail()
+                }
+            })
+        }
+
+        waitForExpectations(timeout: 40, handler: nil)
+    }
+    
+    /*  [
+            1. (Text)
+            2. (Pause: 3s)
+        ]
+        
+        wait 1s from start()
+          <<  3. (Text)
+        wait 2s from start()
+            cancel
+     */
+     func test_25_cancel_all() throws {
+         let expectation = self.expectation(description: "Wait for 30 seconds")
+         let tts = PriorityQueueTTS()
+         var step : Int = 0;
+
+         // 1. (Text)
+         tts.append(entry: QueueEntry(text:sample ) { item, _, reason in
+             switch(reason) {
+             case .Canceled:
+                 XCTAssertTrue( (0...2).contains(step.pass()) )
+                 if step == 2 { expectation.fulfill() }
+             default:
+                 XCTFail()
+             }
+         })
+         
+         // 2. (Pause: 3s)
+         tts.append(entry: QueueEntry( pause: 30 ) { item, _, reason in
+             switch(reason) {
+             case .Canceled:
+                 XCTAssertTrue( (0...2).contains(step.pass()) )
+                 if step == 2 { expectation.fulfill() }
+             default:
+                 XCTFail()
+             }
+         })
+
+         tts.start()
+
+         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+             // <<  3. (Text)
+             tts.append(entry: QueueEntry(text:"<<  3. (Text)" ) { item, _, reason in
+                 switch(reason) {
+                 case .Canceled:
+                     XCTAssertTrue( (0...2).contains(step.pass()) )
+                     if step == 2 { expectation.fulfill() }
+                 default:
+                     XCTFail()
+                 }
+             })
+         }
+
+         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+             tts.cancel()
+         }
+
+         waitForExpectations(timeout: 30, handler: nil)
+    }
+    
+    /*  [
+            1. (Pause: 3s)
+            2. (Text)
+        ]
+        
+        wait 1s from start()
+            cancel
+            << 3. (Text)
+     */
+    func test_26_cancel_pause_continue() throws {
+        let expectation = self.expectation(description: "Wait for 50 seconds")
+        let tts = PriorityQueueTTS()
+        var step : Int = 0;
+
+        // 1. (Pause: 3s)
+        tts.append(entry: QueueEntry( pause: 30 ) { item, _, reason in
+            switch(reason) {
+            case .Canceled:
+                XCTAssertTrue( (0...1).contains(step.pass()) )
+            default:
+                XCTFail()
+            }
+        })
+        // 2. (Text)
+        tts.append(entry: QueueEntry(text:sample ) { item, _, reason in
+            switch(reason) {
+            case .Canceled:
+                XCTAssertTrue( (0...1).contains(step.pass()) )
+            default:
+                XCTFail()
+            }
+        })
+        tts.start()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            tts.cancel()
+            
+            // << 3. (Text)
+            tts.append(entry: QueueEntry(text:"<< 3. (Text)" ) { item, _, reason in
+                switch(reason) {
+                case .Completed:
+                    XCTAssertEqual( 2, step.pass() )
+                    expectation.fulfill()
+                default:
+                    XCTFail()
+                }
+            })
+        }
+        
+        waitForExpectations(timeout: 50, handler: nil)
+   }
 }
 
 

--- a/Tests/PriorityQueueTTSTests/TokenizerEntryTests.swift
+++ b/Tests/PriorityQueueTTSTests/TokenizerEntryTests.swift
@@ -262,4 +262,237 @@ final class TokenizerEntryTests: XCTestCase {
         }
         waitForExpectations(timeout: 15, handler: nil)
     }
+    
+    /*  [
+            (TAG:"A", .Normal) // stop-replace
+        ]
+        <<  (TAG:"A", .Normal)
+     */
+    func test9_tag_replace_1() throws {
+        let expectation = self.expectation(description: "Wait for 30 seconds")
+        let tts = PriorityQueueTTS()
+        var step : Int = 0;
+
+        let entry1 = TokenizerEntry(separator: ".", tag: "A") { entry, reason in
+            switch(reason) {
+            case .Canceled:
+                XCTAssertEqual(0, step.pass())
+            case .Completed:
+                XCTFail()
+            case .Paused:
+                break
+            }
+        }
+        try? entry1.append(text: sample_pause)
+        entry1.close()
+        tts.append(entry: entry1)
+        tts.start()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            // 2)  (TAG:"A", .Normal)
+            let entry2 = TokenizerEntry(separator: ".", tag: "A") { entry, reason in
+                switch(reason) {
+                case .Paused:
+                    XCTAssertEqual(1, step.pass())
+                case .Completed:
+                    XCTAssertEqual(2, step.pass())
+                    expectation.fulfill()
+                case .Canceled:
+                    XCTFail()
+                }
+            }
+            try? entry2.append(text:"(TAG:A, .Normal)")
+            entry2.close()
+            tts.append(entry: entry2, withRemoving: SameTag)
+        }
+        
+        waitForExpectations(timeout: 30, handler: nil)
+    }
+    
+    /*  [
+            (TAG:"A", .Normal) // stop-replace
+            (TAG:"A", .Normal) // remove
+        ]
+        <<  (TAG:"A", .Normal)
+     */
+    func test10_tag_replace_2() throws {
+        let expectation = self.expectation(description: "Wait for 30 seconds")
+        let tts = PriorityQueueTTS()
+        var step : Int = 0;
+
+        let entry1 = TokenizerEntry(separator: ".", tag: "A") { entry, reason in
+            switch(reason) {
+            case .Canceled:
+                XCTAssertTrue( (0...1).contains(step.pass()) )
+            case .Completed:
+                XCTFail()
+            case .Paused:
+                break
+            }
+        }
+        try? entry1.append(text: sample_pause)
+        entry1.close()
+        tts.append(entry: entry1)
+        
+        // 2) (TAG:"A", .Normal) // remove
+        let entry2 = TokenizerEntry(separator: ".", tag: "A") { entry, reason in
+            switch(reason) {
+            case .Canceled:
+                XCTAssertTrue( (0...1).contains(step.pass()) )
+            case .Completed:
+                XCTFail()
+            case .Paused:
+                break
+            }
+        }
+        try? entry2.append(text: "2) (TAG:A, .Normal) // remove")
+        entry2.close()
+        tts.append(entry: entry2)
+
+        tts.start()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            // 3)  (TAG:"A", .Normal)
+            let entry3 = TokenizerEntry(separator: ".", tag: "A") { entry, reason in
+                switch(reason) {
+                case .Paused:
+                    XCTAssertEqual(2, step.pass())
+                case .Completed:
+                    XCTAssertEqual(3, step.pass())
+                    expectation.fulfill()
+                case .Canceled:
+                    XCTFail()
+                }
+            }
+            try? entry3.append(text:"3) (TAG:A, .Normal)")
+            entry3.close()
+            tts.append(entry: entry3, withRemoving: SameTag)
+        }
+
+        waitForExpectations(timeout: 30, handler: nil)
+    }
+
+    /*  [
+            (TAG:"Def", .Normal) // keep
+            (TAG:"A", .Normal) // remove
+        ]
+        <<  (TAG:"A", .Normal)
+     */
+    func test11_tag_replace_keep_remove() throws {
+        let expectation = self.expectation(description: "Wait for 30 seconds")
+        let tts = PriorityQueueTTS()
+        var step : Int = 0;
+
+        // 1) (TAG:"Def", .Normal) // keep
+        let entry1 = TokenizerEntry(separator: ".") { entry, reason in
+            switch(reason) {
+            case .Paused:
+                XCTAssertTrue( (0...2).contains(step.pass()) )
+            case .Completed:
+                XCTAssertEqual(3, step.pass())
+            case .Canceled:
+                XCTFail()
+            }
+        }
+        try? entry1.append(text: sample_pause)
+        entry1.close()
+        tts.append(entry: entry1)
+        
+        // 2) (TAG:"A", .Normal) // remove
+        let entry2 = TokenizerEntry(separator: ".", tag: "A") { entry, reason in
+            switch(reason) {
+            case .Canceled:
+                XCTAssertTrue( (0...2).contains(step.pass()) )
+            default:
+                XCTFail()
+            }
+        }
+        try? entry2.append(text: "2) (TAG:A, .Normal) // remove")
+        entry2.close()
+        tts.append(entry: entry2)
+
+        tts.start()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            // 3)  (TAG:"A", .Normal)
+            let entry3 = TokenizerEntry(separator: ".", tag: "A") { entry, reason in
+                switch(reason) {
+                case .Paused:
+                    XCTAssertEqual(4, step.pass())
+                case .Completed:
+                    XCTAssertEqual(5, step.pass())
+                    expectation.fulfill()
+                case .Canceled:
+                    XCTFail()
+                }
+            }
+            try? entry3.append(text:"3) (TAG:A, .Normal)")
+            entry3.close()
+            tts.append(entry: entry3, withRemoving: SameTag)
+        }
+
+        waitForExpectations(timeout: 30, handler: nil)
+    }
+
+    /*  [
+            (TAG:"Def", .High) // interrupt
+            (TAG:"A", .Normal) // remove
+        ]
+        <<  (TAG:"A", .Required)
+     */
+    func test12_tag_replace_interrupt() throws {
+        let expectation = self.expectation(description: "Wait for 30 seconds")
+        let tts = PriorityQueueTTS()
+        var step : Int = 0;
+
+        // 1) (TAG:"Def", .High) // interrupt
+        let entry1 = TokenizerEntry(separator: ".", priority: .High) { entry, reason in
+            switch(reason) {
+            case .Paused:
+                XCTAssertTrue( Set([0,1,4,5]).contains(step.pass()) )
+            case .Completed:
+                XCTAssertEqual(6, step.pass())
+                expectation.fulfill()
+            case .Canceled:
+                XCTFail()
+            }
+        }
+        try? entry1.append(text: sample_pause)
+        entry1.close()
+        tts.append(entry: entry1)
+        
+        // 2) (TAG:"A", .Normal) // remove
+        let entry2 = TokenizerEntry(separator: ".", tag: "A") { entry, reason in
+            switch(reason) {
+            case .Canceled:
+                XCTAssertTrue( Set([0,1]).contains(step.pass()) )
+            default:
+                XCTFail()
+            }
+        }
+        try? entry2.append(text: "2) (TAG:A, .Normal) // remove")
+        entry2.close()
+        tts.append(entry: entry2)
+
+        tts.start()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            // 3) (TAG:"A", .Required)
+            let entry3 = TokenizerEntry(separator: ".", priority: .Required, tag: "A") { entry, reason in
+                switch(reason) {
+                case .Paused:
+                    XCTAssertEqual(2, step.pass())
+                case .Completed:
+                    XCTAssertEqual(3, step.pass())
+                case .Canceled:
+                    XCTFail()
+                }
+            }
+            try? entry3.append(text:"3) (TAG:A, .Required)")
+            entry3.close()
+            tts.append(entry: entry3, withRemoving: SameTag)
+        }
+
+        waitForExpectations(timeout: 30, handler: nil)
+    }
 }

--- a/Tests/PriorityQueueTTSTests/TokenizerEntryTests.swift
+++ b/Tests/PriorityQueueTTSTests/TokenizerEntryTests.swift
@@ -440,7 +440,7 @@ final class TokenizerEntryTests: XCTestCase {
         ]
         <<  (TAG:"A", .Required)
      */
-    func test12_tag_replace_interrupt() throws {
+    func test12_tag_interrupt_remove() throws {
         let expectation = self.expectation(description: "Wait for 30 seconds")
         let tts = PriorityQueueTTS()
         var step : Int = 0;
@@ -491,6 +491,118 @@ final class TokenizerEntryTests: XCTestCase {
             try? entry3.append(text:"3) (TAG:A, .Required)")
             entry3.close()
             tts.append(entry: entry3, withRemoving: SameTag)
+        }
+
+        waitForExpectations(timeout: 30, handler: nil)
+    }
+    
+    /*  [
+            1. (Text TAG:"A") // stop-replace not closed
+        ]
+        wait 1s from start()
+            << 2. (Text TAG:"A")
+        wait 3s from start()
+            (1. append text, close)
+     */
+    func test13_tag_replace_before_close() throws {
+        let expectation = self.expectation(description: "Wait for 30 seconds")
+        let tts = PriorityQueueTTS()
+        var step : Int = 0;
+
+        // 1. (Text TAG:"A") // stop-replace not closed
+        let entry1 = TokenizerEntry(separator: ".", tag: "A") { entry, reason in
+            switch(reason) {
+            case .Canceled:
+                XCTAssertTrue( (0...1).contains(step.pass()) )
+            default:
+                XCTFail()
+            }
+        }
+        try? entry1.append(text: sample_pause)
+        tts.append(entry: entry1)
+        
+        tts.start()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            //  << 2. (Text TAG:"A")
+            let entry2 = TokenizerEntry(separator: ".", tag: "A") { entry, reason in
+                switch(reason) {
+                case .Paused:
+                    XCTAssertTrue( (0...1).contains(step.pass()) )
+                case .Completed:
+                    XCTAssertEqual(2, step.pass())
+                case .Canceled:
+                    XCTFail()
+                }
+            }
+            try? entry2.append(text: "<< 2. (Text TAG:A)")
+            entry2.close()
+            tts.append(entry: entry2, withRemoving: SameTag)
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            // (1. append text, close)
+            do {
+                try entry1.append(text: "may be cancelled")
+                entry1.close()
+            }
+            catch {
+                XCTFail()
+            }
+            expectation.fulfill()
+        }
+        
+        waitForExpectations(timeout: 30, handler: nil)
+    }
+    
+    /*  [
+            1. (Text .Normal, timeout: 4s) // interrupt -> timeout
+        ]
+        wait 1s from start()
+             << 2. (Pause:3s .Required)
+             << 3. (Text .Required)
+     */
+    func test14_interrupt_timeout() throws {
+        let expectation = self.expectation(description: "Wait for 30 seconds")
+        let tts = PriorityQueueTTS()
+        var step : Int = 0;
+
+        // 1. (Text .Normal) // interrupt -> timeout
+        let entry1 = TokenizerEntry(separator: ".", priority: .Normal, timeout_sec: 4) { entry, reason in
+            switch(reason) {
+            case .Paused:
+                XCTAssertEqual(0, step.pass())
+            case .Canceled:
+                XCTAssertEqual(3, step.pass())
+                expectation.fulfill()
+            default:
+                XCTFail()
+            }
+        }
+        try? entry1.append(text: sample_pause)
+        entry1.close()
+        tts.append(entry: entry1)
+        tts.start()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            //  << 2. (Pause:3s .Required)
+            tts.append(entry: QueueEntry(pause: 30, priority: .Required) { item, _, reason in
+                switch(reason) {
+                case .Completed:
+                    XCTAssertEqual(1, step.pass() )
+                default:
+                    XCTFail()
+                }
+            })
+            //  << 3. (Text .Required)
+            tts.append(entry: QueueEntry(text: "<< 3. (Text .Required)", priority: .Required) { item, _, reason in
+                switch(reason) {
+                case .Completed:
+                    XCTAssertEqual(2, step.pass() )
+                default:
+                    XCTFail()
+                }
+            })
         }
 
         waitForExpectations(timeout: 30, handler: nil)


### PR DESCRIPTION
[ISSUE #397](https://github.com/CMU-cabot/TODO-Consortium/issues/397) の対応となります。

* 表題の対応は、エントリを追加する際、以下の様に呼ぶ様にしました。
    ```
     tts.append( entry: entry, withRemoving: SameTag )
    ```
    * withRemoving は `(_ base: QueueEntry, _ test: QueueEntry) -> Bool ` 型のクロージャーを受け取れるので同一タグ除去以外の指定も可能です。
* エントリが「同一タグ除去」「タイムアウト」「明示的キャンセル呼び出し」によってキャンセルされた場合、エントリのコールバックを .Canceled で呼ばれる様に修正しました。

ご指摘あればお願いいたします。