### PR TITLE
add tts options to QueueEntry, fix test of TokenizerEntry

### DIFF
--- a/Sources/PriorityQueueTTS/QueueEntry.swift
+++ b/Sources/PriorityQueueTTS/QueueEntry.swift
@@ -55,6 +55,9 @@ public class QueueEntry: Comparable, Hashable {
     public let created_time: TimeInterval
     public let expire_at: TimeInterval
     public let tag: Tag
+    public let volume :Float
+    public let speechRate :Float
+    public let voice :AVSpeechSynthesisVoice?
     public var completion: ((_ entry: QueueEntry, _ utterance: AVSpeechUtterance?, _ reason: CompletionReason) -> Void)?
     public func is_completed() -> Bool {
         return status == .completed
@@ -64,7 +67,7 @@ public class QueueEntry: Comparable, Hashable {
         case completed
         case canceled
     }
-    internal private (set) var status: Status = .working
+    internal private(set) var status: Status = .working
     public func mark_canceled() {
         status = .canceled
     }
@@ -77,6 +80,9 @@ public class QueueEntry: Comparable, Hashable {
         priority: SpeechPriority,
         timeout_sec: TimeInterval,
         tag: Tag,
+        volume :Float,
+        speechRate :Float,
+        voice :AVSpeechSynthesisVoice?,
         completion: ((_: QueueEntry, _: AVSpeechUtterance?, _: CompletionReason) -> Void)?
     ) {
         if let token = token {
@@ -87,6 +93,9 @@ public class QueueEntry: Comparable, Hashable {
         self.created_time = Date().timeIntervalSince1970
         self.expire_at = self.created_time + timeout_sec
         self.tag = tag
+        self.volume = volume
+        self.speechRate = speechRate
+        self.voice = voice
         self.completion = completion
     }
 
@@ -97,7 +106,7 @@ public class QueueEntry: Comparable, Hashable {
         tag: Tag = .Default,
         completion: ((_ entry: QueueEntry, _ utteracne: AVSpeechUtterance?, _ reason: CompletionReason) -> Void)? = nil
     ) {
-        self.init(token: Token.Pause(pause), priority: priority, timeout_sec: timeout_sec, tag: tag, completion: completion)
+        self.init(token: Token.Pause(pause), priority: priority, timeout_sec: timeout_sec, tag: tag, volume: 0, speechRate: 0, voice: nil, completion: completion)
     }
 
     public convenience init(
@@ -105,9 +114,12 @@ public class QueueEntry: Comparable, Hashable {
         priority: SpeechPriority = .Normal,
         timeout_sec: TimeInterval = 10.0,
         tag: Tag = .Default,
+        volume :Float = 1.0,
+        speechRate :Float = 0.5,
+        voice :AVSpeechSynthesisVoice? = nil,
         completion: ((_ entry: QueueEntry, _ utteracne: AVSpeechUtterance?, _ reason: CompletionReason) -> Void)? = nil
     ) {
-        self.init(token: Token.Text(text), priority: priority, timeout_sec: timeout_sec, tag: tag, completion: completion)
+        self.init(token: Token.Text(text), priority: priority, timeout_sec: timeout_sec, tag: tag, volume: volume, speechRate: speechRate, voice: voice, completion: completion)
     }
 
     func progress(with range: NSRange?) {

--- a/Sources/PriorityQueueTTS/TokenizerEntry.swift
+++ b/Sources/PriorityQueueTTS/TokenizerEntry.swift
@@ -42,6 +42,9 @@ public class TokenizerEntry: QueueEntry {
         priority: SpeechPriority = .Normal,
         timeout_sec: TimeInterval = 10.0,
         tag: Tag = .Default,
+        volume :Float = 1.0,
+        speechRate :Float = 0.5,
+        voice :AVSpeechSynthesisVoice? = nil,
         completion: ((_ entry: QueueEntry, _ reason: CompletionReason) -> Void)? = nil
     ) {
         self.separators = separators
@@ -50,7 +53,7 @@ public class TokenizerEntry: QueueEntry {
         self.startIndex = _buffer.startIndex
         self.closed = false
         self._completion = completion
-        super.init(token: nil, priority: priority, timeout_sec: timeout_sec, tag: tag, completion: nil)
+        super.init(token: nil, priority: priority, timeout_sec: timeout_sec, tag: tag, volume: volume, speechRate: speechRate, voice: voice, completion: nil)
         self.completion = { entry, utterance, reason in
             switch(reason) {
             case .Completed:

--- a/Tests/PriorityQueueTTSTests/TokenizerEntryTests.swift
+++ b/Tests/PriorityQueueTTSTests/TokenizerEntryTests.swift
@@ -31,7 +31,7 @@ final class TokenizerEntryTests: XCTestCase {
     let long_sample_pause: String = "This is a sample message... All the message should be read... This is a sample message... All the message should be read."
 
     func test1_add_pause() throws {
-        let item = TokenizerEntry(separator: ".")
+        let item = TokenizerEntry(separators: ["."])
         try? item.append(text: sample_pause)
         item.close()
         XCTAssertEqual(item.tokens.count, 3)
@@ -43,7 +43,7 @@ final class TokenizerEntryTests: XCTestCase {
     func test2_process_tokenizer_item() throws {
         let expectation = self.expectation(description: "Wait for 15 seconds")
         let tts = PriorityQueueTTS()
-        let item = TokenizerEntry(separator: ".") { entry, reason in
+        let item = TokenizerEntry(separators: ["."]) { entry, reason in
             if reason == .Completed {
                 expectation.fulfill()
             }
@@ -56,7 +56,7 @@ final class TokenizerEntryTests: XCTestCase {
     }
 
     func test3_no_pause() throws {
-        let item = TokenizerEntry(separator: ".")
+        let item = TokenizerEntry(separators: ["."])
         try? item.append(text: sample)
         item.close()
         XCTAssertEqual(item.tokens.count, 2)
@@ -67,7 +67,7 @@ final class TokenizerEntryTests: XCTestCase {
     func test3_2_process_tokenizer_item() throws {
         let expectation = self.expectation(description: "Wait for 15 seconds")
         let tts = PriorityQueueTTS()
-        let item = TokenizerEntry(separator: ".") { entry, reason in
+        let item = TokenizerEntry(separators: ["."]) { entry, reason in
             if reason == .Completed {
                 expectation.fulfill()
             }
@@ -83,7 +83,7 @@ final class TokenizerEntryTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for 30 seconds")
         let tts = PriorityQueueTTS()
         var response = 0
-        let item = TokenizerEntry(separator: ".", timeout_sec: 30) { entry, reason in
+        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, reason in
             response += 1
             if (response == 4) {
                 expectation.fulfill()
@@ -111,7 +111,7 @@ final class TokenizerEntryTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for 30 seconds")
         let tts = PriorityQueueTTS()
         var response = 0
-        let item = TokenizerEntry(separator: ".", timeout_sec: 30) { entry, reason in
+        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, reason in
             response += 1
             if (response == 7) {
                 expectation.fulfill()
@@ -164,7 +164,7 @@ final class TokenizerEntryTests: XCTestCase {
         }
         let delegate = Delegate()
         tts.delegate = delegate
-        let item = TokenizerEntry(separator: ".", timeout_sec: 30) { entry, reason in
+        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, reason in
             if reason == .Completed {
                 expectation.fulfill()
             }
@@ -207,7 +207,7 @@ final class TokenizerEntryTests: XCTestCase {
         }
         let delegate = Delegate()
         tts.delegate = delegate
-        let item = TokenizerEntry(separator: ".", timeout_sec: 30) { entry, reason in
+        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, reason in
             if reason == .Completed {
                 expectation.fulfill()
             }
@@ -247,7 +247,7 @@ final class TokenizerEntryTests: XCTestCase {
         }
         let delegate = Delegate()
         tts.delegate = delegate
-        let item = TokenizerEntry(separator: ".", timeout_sec: 30) { entry, reason in
+        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, reason in
             if reason == .Completed {
                 expectation.fulfill()
             }
@@ -273,7 +273,7 @@ final class TokenizerEntryTests: XCTestCase {
         let tts = PriorityQueueTTS()
         var step : Int = 0;
 
-        let entry1 = TokenizerEntry(separator: ".", tag: "A") { entry, reason in
+        let entry1 = TokenizerEntry(separators: ["."], tag: "A") { entry, reason in
             switch(reason) {
             case .Canceled:
                 XCTAssertEqual(0, step.pass())
@@ -290,7 +290,7 @@ final class TokenizerEntryTests: XCTestCase {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             // 2)  (TAG:"A", .Normal)
-            let entry2 = TokenizerEntry(separator: ".", tag: "A") { entry, reason in
+            let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, reason in
                 switch(reason) {
                 case .Paused:
                     XCTAssertEqual(1, step.pass())
@@ -320,7 +320,7 @@ final class TokenizerEntryTests: XCTestCase {
         let tts = PriorityQueueTTS()
         var step : Int = 0;
 
-        let entry1 = TokenizerEntry(separator: ".", tag: "A") { entry, reason in
+        let entry1 = TokenizerEntry(separators: ["."], tag: "A") { entry, reason in
             switch(reason) {
             case .Canceled:
                 XCTAssertTrue( (0...1).contains(step.pass()) )
@@ -335,7 +335,7 @@ final class TokenizerEntryTests: XCTestCase {
         tts.append(entry: entry1)
         
         // 2) (TAG:"A", .Normal) // remove
-        let entry2 = TokenizerEntry(separator: ".", tag: "A") { entry, reason in
+        let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, reason in
             switch(reason) {
             case .Canceled:
                 XCTAssertTrue( (0...1).contains(step.pass()) )
@@ -353,7 +353,7 @@ final class TokenizerEntryTests: XCTestCase {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
             // 3)  (TAG:"A", .Normal)
-            let entry3 = TokenizerEntry(separator: ".", tag: "A") { entry, reason in
+            let entry3 = TokenizerEntry(separators: ["."], tag: "A") { entry, reason in
                 switch(reason) {
                 case .Paused:
                     XCTAssertEqual(2, step.pass())
@@ -384,7 +384,7 @@ final class TokenizerEntryTests: XCTestCase {
         var step : Int = 0;
 
         // 1) (TAG:"Def", .Normal) // keep
-        let entry1 = TokenizerEntry(separator: ".") { entry, reason in
+        let entry1 = TokenizerEntry(separators: ["."]) { entry, reason in
             switch(reason) {
             case .Paused:
                 XCTAssertTrue( (0...2).contains(step.pass()) )
@@ -399,7 +399,7 @@ final class TokenizerEntryTests: XCTestCase {
         tts.append(entry: entry1)
         
         // 2) (TAG:"A", .Normal) // remove
-        let entry2 = TokenizerEntry(separator: ".", tag: "A") { entry, reason in
+        let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, reason in
             switch(reason) {
             case .Canceled:
                 XCTAssertTrue( (0...2).contains(step.pass()) )
@@ -415,7 +415,7 @@ final class TokenizerEntryTests: XCTestCase {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
             // 3)  (TAG:"A", .Normal)
-            let entry3 = TokenizerEntry(separator: ".", tag: "A") { entry, reason in
+            let entry3 = TokenizerEntry(separators: ["."], tag: "A") { entry, reason in
                 switch(reason) {
                 case .Paused:
                     XCTAssertEqual(4, step.pass())
@@ -446,7 +446,7 @@ final class TokenizerEntryTests: XCTestCase {
         var step : Int = 0;
 
         // 1) (TAG:"Def", .High) // interrupt
-        let entry1 = TokenizerEntry(separator: ".", priority: .High) { entry, reason in
+        let entry1 = TokenizerEntry(separators: ["."], priority: .High) { entry, reason in
             switch(reason) {
             case .Paused:
                 XCTAssertTrue( Set([0,1,4,5]).contains(step.pass()) )
@@ -462,7 +462,7 @@ final class TokenizerEntryTests: XCTestCase {
         tts.append(entry: entry1)
         
         // 2) (TAG:"A", .Normal) // remove
-        let entry2 = TokenizerEntry(separator: ".", tag: "A") { entry, reason in
+        let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, reason in
             switch(reason) {
             case .Canceled:
                 XCTAssertTrue( Set([0,1]).contains(step.pass()) )
@@ -478,7 +478,7 @@ final class TokenizerEntryTests: XCTestCase {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             // 3) (TAG:"A", .Required)
-            let entry3 = TokenizerEntry(separator: ".", priority: .Required, tag: "A") { entry, reason in
+            let entry3 = TokenizerEntry(separators: ["."], priority: .Required, tag: "A") { entry, reason in
                 switch(reason) {
                 case .Paused:
                     XCTAssertEqual(2, step.pass())
@@ -510,7 +510,7 @@ final class TokenizerEntryTests: XCTestCase {
         var step : Int = 0;
 
         // 1. (Text TAG:"A") // stop-replace not closed
-        let entry1 = TokenizerEntry(separator: ".", tag: "A") { entry, reason in
+        let entry1 = TokenizerEntry(separators: ["."], tag: "A") { entry, reason in
             switch(reason) {
             case .Canceled:
                 XCTAssertTrue( (0...1).contains(step.pass()) )
@@ -525,7 +525,7 @@ final class TokenizerEntryTests: XCTestCase {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             //  << 2. (Text TAG:"A")
-            let entry2 = TokenizerEntry(separator: ".", tag: "A") { entry, reason in
+            let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, reason in
                 switch(reason) {
                 case .Paused:
                     XCTAssertTrue( (0...1).contains(step.pass()) )
@@ -568,7 +568,7 @@ final class TokenizerEntryTests: XCTestCase {
         var step : Int = 0;
 
         // 1. (Text .Normal) // interrupt -> timeout
-        let entry1 = TokenizerEntry(separator: ".", priority: .Normal, timeout_sec: 4) { entry, reason in
+        let entry1 = TokenizerEntry(separators: ["."], priority: .Normal, timeout_sec: 4) { entry, reason in
             switch(reason) {
             case .Paused:
                 XCTAssertEqual(0, step.pass())


### PR DESCRIPTION
1. QueueEntry、及び、TokenizerEntry に TTS スピークのオプション値となる「volume」「speechRate」「voice」を保持出来る様、修正しました。
    * 伴い、UT（test_27_speach_options）を追加しました。
        * utterance の属性値確認と、テスト実行時の音声の違い（これは耳で確認）
2. TokenizerEntry のinit() 修正を TokenizerEntryTests.swift に反映させました
3. cancel() 時に キャンセルバウンダリを指定できるように修正しました。
    * 勝原の勘違いで、もともと内部関数 stopProcessingImmediately() では バウンダリ指定可能でした。ただ、外部公開の cancel では明示指定出来なかったので修正しています
        * バウンダリを .immediate に変更してUTを動作させてみましたが特に変な挙動はありませんでした
