### PR TITLE
Token.readingRange to public

### DIFF
--- a/Sources/PriorityQueueTTS/Token.swift
+++ b/Sources/PriorityQueueTTS/Token.swift
@@ -31,7 +31,7 @@ public class Token {
     public var type: TokenType
     public var text: String?
     public var pause: Int?
-    var readingRange: NSRange?
+    public var readingRange: NSRange?
     public var spokenText: String? {
         get {
             if let text = text {


### PR DESCRIPTION
PriorityQueueTTSDelegate の progress が
``` 
func progress(queue: PriorityQueueTTS, entry: QueueEntry)
```
となっていて、entry から readingRange にアクセスできない為、public 化しました