### PR TITLE
Feature/buffered speach range

### DIFF
--- a/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
+++ b/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
@@ -152,10 +152,9 @@ public class PriorityQueueTTS: NSObject {
     }
 
     private func progress(range: NSRange, utterance: AVSpeechUtterance) {
-        guard let delegate = delegate else { return }
         guard let entry = processingEntry else { return }
         entry.progress(with: range)
-        delegate.progress(queue: self, entry: entry)
+        delegate?.progress(queue: self, entry: entry)
     }
 
     private func finish(utterance: AVSpeechUtterance?) {

--- a/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
+++ b/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
@@ -188,6 +188,10 @@ public class PriorityQueueTTS: NSObject {
         speakingRange = nil
         pausing = nil
     }
+    
+    public var isSpeaking : Bool {
+        return tts.isSpeaking && !tts.isPaused
+    }
 }
 
 extension PriorityQueueTTS: AVSpeechSynthesizerDelegate {

--- a/Sources/PriorityQueueTTS/SpeechPriority.swift
+++ b/Sources/PriorityQueueTTS/SpeechPriority.swift
@@ -36,3 +36,5 @@ extension SpeechPriority: Comparable {
         lhs.rawValue < rhs.rawValue
     }
 }
+
+typealias SpeechQueuePriority = SpeechPriority

--- a/Sources/PriorityQueueTTS/SpeechPriority.swift
+++ b/Sources/PriorityQueueTTS/SpeechPriority.swift
@@ -37,4 +37,4 @@ extension SpeechPriority: Comparable {
     }
 }
 
-typealias SpeechQueuePriority = SpeechPriority
+public typealias SpeechQueuePriority = SpeechPriority

--- a/Sources/PriorityQueueTTS/TokenizerEntry.swift
+++ b/Sources/PriorityQueueTTS/TokenizerEntry.swift
@@ -35,7 +35,7 @@ public class TokenizerEntry: QueueEntry {
     private var cursor: Int
     private var startIndex: String.Index
     private var closed: Bool
-    private var _completion: ((_ entry: QueueEntry, _ reason: CompletionReason) -> Void)? = nil
+    private var _completion: ((_: QueueEntry, _: AVSpeechUtterance?, _: CompletionReason) -> Void)? = nil
 
     public init(
         separators: [String],
@@ -45,7 +45,7 @@ public class TokenizerEntry: QueueEntry {
         volume :Float = 1.0,
         speechRate :Float = 0.5,
         voice :AVSpeechSynthesisVoice? = nil,
-        completion: ((_ entry: QueueEntry, _ reason: CompletionReason) -> Void)? = nil
+        completion: ((_: QueueEntry, _: AVSpeechUtterance?, _: CompletionReason) -> Void)? = nil
     ) {
         self.separators = separators
         self.separatorCount = 0
@@ -63,7 +63,7 @@ public class TokenizerEntry: QueueEntry {
                 break
             }
             guard let _completion = self._completion else { return }
-            _completion(entry, reason)
+            _completion(entry, utterance, reason)
         }
     }
 

--- a/Tests/PriorityQueueTTSTests/TokenizerEntryTests.swift
+++ b/Tests/PriorityQueueTTSTests/TokenizerEntryTests.swift
@@ -43,7 +43,7 @@ final class TokenizerEntryTests: XCTestCase {
     func test2_process_tokenizer_item() throws {
         let expectation = self.expectation(description: "Wait for 15 seconds")
         let tts = PriorityQueueTTS()
-        let item = TokenizerEntry(separators: ["."]) { entry, reason in
+        let item = TokenizerEntry(separators: ["."]) { entry, utterance, reason in
             if reason == .Completed {
                 expectation.fulfill()
             }
@@ -67,7 +67,7 @@ final class TokenizerEntryTests: XCTestCase {
     func test3_2_process_tokenizer_item() throws {
         let expectation = self.expectation(description: "Wait for 15 seconds")
         let tts = PriorityQueueTTS()
-        let item = TokenizerEntry(separators: ["."]) { entry, reason in
+        let item = TokenizerEntry(separators: ["."]) { entry, utterance, reason in
             if reason == .Completed {
                 expectation.fulfill()
             }
@@ -83,7 +83,7 @@ final class TokenizerEntryTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for 30 seconds")
         let tts = PriorityQueueTTS()
         var response = 0
-        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, reason in
+        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, utterance, reason in
             response += 1
             if (response == 4) {
                 expectation.fulfill()
@@ -111,7 +111,7 @@ final class TokenizerEntryTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for 30 seconds")
         let tts = PriorityQueueTTS()
         var response = 0
-        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, reason in
+        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, utterance, reason in
             response += 1
             if (response == 7) {
                 expectation.fulfill()
@@ -164,7 +164,7 @@ final class TokenizerEntryTests: XCTestCase {
         }
         let delegate = Delegate()
         tts.delegate = delegate
-        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, reason in
+        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, utterance, reason in
             if reason == .Completed {
                 expectation.fulfill()
             }
@@ -207,7 +207,7 @@ final class TokenizerEntryTests: XCTestCase {
         }
         let delegate = Delegate()
         tts.delegate = delegate
-        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, reason in
+        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, utterance, reason in
             if reason == .Completed {
                 expectation.fulfill()
             }
@@ -247,7 +247,7 @@ final class TokenizerEntryTests: XCTestCase {
         }
         let delegate = Delegate()
         tts.delegate = delegate
-        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, reason in
+        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, utterance, reason in
             if reason == .Completed {
                 expectation.fulfill()
             }
@@ -273,7 +273,7 @@ final class TokenizerEntryTests: XCTestCase {
         let tts = PriorityQueueTTS()
         var step : Int = 0;
 
-        let entry1 = TokenizerEntry(separators: ["."], tag: "A") { entry, reason in
+        let entry1 = TokenizerEntry(separators: ["."], tag: "A") { entry, utterance, reason in
             switch(reason) {
             case .Canceled:
                 XCTAssertEqual(0, step.pass())
@@ -290,7 +290,7 @@ final class TokenizerEntryTests: XCTestCase {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             // 2)  (TAG:"A", .Normal)
-            let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, reason in
+            let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, utterance, reason in
                 switch(reason) {
                 case .Paused:
                     XCTAssertEqual(1, step.pass())
@@ -320,7 +320,7 @@ final class TokenizerEntryTests: XCTestCase {
         let tts = PriorityQueueTTS()
         var step : Int = 0;
 
-        let entry1 = TokenizerEntry(separators: ["."], tag: "A") { entry, reason in
+        let entry1 = TokenizerEntry(separators: ["."], tag: "A") { entry, utterance, reason in
             switch(reason) {
             case .Canceled:
                 XCTAssertTrue( (0...1).contains(step.pass()) )
@@ -335,7 +335,7 @@ final class TokenizerEntryTests: XCTestCase {
         tts.append(entry: entry1)
         
         // 2) (TAG:"A", .Normal) // remove
-        let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, reason in
+        let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, utterance, reason in
             switch(reason) {
             case .Canceled:
                 XCTAssertTrue( (0...1).contains(step.pass()) )
@@ -353,7 +353,7 @@ final class TokenizerEntryTests: XCTestCase {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
             // 3)  (TAG:"A", .Normal)
-            let entry3 = TokenizerEntry(separators: ["."], tag: "A") { entry, reason in
+            let entry3 = TokenizerEntry(separators: ["."], tag: "A") { entry, utterance, reason in
                 switch(reason) {
                 case .Paused:
                     XCTAssertEqual(2, step.pass())
@@ -384,7 +384,7 @@ final class TokenizerEntryTests: XCTestCase {
         var step : Int = 0;
 
         // 1) (TAG:"Def", .Normal) // keep
-        let entry1 = TokenizerEntry(separators: ["."]) { entry, reason in
+        let entry1 = TokenizerEntry(separators: ["."]) { entry, utterance, reason in
             switch(reason) {
             case .Paused:
                 XCTAssertTrue( (0...2).contains(step.pass()) )
@@ -399,7 +399,7 @@ final class TokenizerEntryTests: XCTestCase {
         tts.append(entry: entry1)
         
         // 2) (TAG:"A", .Normal) // remove
-        let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, reason in
+        let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, utterance, reason in
             switch(reason) {
             case .Canceled:
                 XCTAssertTrue( (0...2).contains(step.pass()) )
@@ -415,7 +415,7 @@ final class TokenizerEntryTests: XCTestCase {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
             // 3)  (TAG:"A", .Normal)
-            let entry3 = TokenizerEntry(separators: ["."], tag: "A") { entry, reason in
+            let entry3 = TokenizerEntry(separators: ["."], tag: "A") { entry, utterance, reason in
                 switch(reason) {
                 case .Paused:
                     XCTAssertEqual(4, step.pass())
@@ -446,7 +446,7 @@ final class TokenizerEntryTests: XCTestCase {
         var step : Int = 0;
 
         // 1) (TAG:"Def", .High) // interrupt
-        let entry1 = TokenizerEntry(separators: ["."], priority: .High) { entry, reason in
+        let entry1 = TokenizerEntry(separators: ["."], priority: .High) { entry, utterance, reason in
             switch(reason) {
             case .Paused:
                 XCTAssertTrue( Set([0,1,4,5]).contains(step.pass()) )
@@ -462,7 +462,7 @@ final class TokenizerEntryTests: XCTestCase {
         tts.append(entry: entry1)
         
         // 2) (TAG:"A", .Normal) // remove
-        let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, reason in
+        let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, utterance, reason in
             switch(reason) {
             case .Canceled:
                 XCTAssertTrue( Set([0,1]).contains(step.pass()) )
@@ -478,7 +478,7 @@ final class TokenizerEntryTests: XCTestCase {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             // 3) (TAG:"A", .Required)
-            let entry3 = TokenizerEntry(separators: ["."], priority: .Required, tag: "A") { entry, reason in
+            let entry3 = TokenizerEntry(separators: ["."], priority: .Required, tag: "A") { entry, utterance, reason in
                 switch(reason) {
                 case .Paused:
                     XCTAssertEqual(2, step.pass())
@@ -510,7 +510,7 @@ final class TokenizerEntryTests: XCTestCase {
         var step : Int = 0;
 
         // 1. (Text TAG:"A") // stop-replace not closed
-        let entry1 = TokenizerEntry(separators: ["."], tag: "A") { entry, reason in
+        let entry1 = TokenizerEntry(separators: ["."], tag: "A") { entry, utterance, reason in
             switch(reason) {
             case .Canceled:
                 XCTAssertTrue( (0...1).contains(step.pass()) )
@@ -525,7 +525,7 @@ final class TokenizerEntryTests: XCTestCase {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             //  << 2. (Text TAG:"A")
-            let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, reason in
+            let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, utterance, reason in
                 switch(reason) {
                 case .Paused:
                     XCTAssertTrue( (0...1).contains(step.pass()) )
@@ -568,7 +568,7 @@ final class TokenizerEntryTests: XCTestCase {
         var step : Int = 0;
 
         // 1. (Text .Normal) // interrupt -> timeout
-        let entry1 = TokenizerEntry(separators: ["."], priority: .Normal, timeout_sec: 4) { entry, reason in
+        let entry1 = TokenizerEntry(separators: ["."], priority: .Normal, timeout_sec: 4) { entry, utterance, reason in
             switch(reason) {
             case .Paused:
                 XCTAssertEqual(0, step.pass())


### PR DESCRIPTION
対応内容

* `typealias SpeechQueuePriority = SpeechPriority` の定義追加
  * このパッケージ名は「PriorityQueueTTS」だが、"PriorityQueueTTS" という同名クラスも存在する為、パッケージ利用側で PriorityQueueTTS.SpeechPriority の様に名前空間指定するとコンパイルエラーとなる
    * 「PriorityQueueTTS」というクラスにSpeechPriority はない、となる
* （NavDeviceTTS と同様、）読上げ範囲長さを５文字程度にして、読上げ progress コールバックに報告する
  *  読上げ範囲の履歴を保持し、過去範囲と合成して５文字程度の発話範囲として自然な長さに整形する
* TokenizerEntry 完了コールバックに、最後に読上げたトークン文字列を渡す様に修正
  * 利用側で処理対象のトークン文字列が必要だった
