### PR TITLE
Fix/suspended token range

### DIFF
--- a/Sources/PriorityQueueTTS/Extension.swift
+++ b/Sources/PriorityQueueTTS/Extension.swift
@@ -46,4 +46,12 @@ extension NSRange {
         self.location = self.location + self.length + range.location
         self.length = range.length
     }
+    
+    var nextLocation : Int {
+        return self.location + self.length
+    }
+    
+    func shift( _ shift: Int ) -> NSRange {
+        return NSRange(location: self.location + shift, length: self.length)
+    }
 }

--- a/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
+++ b/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
@@ -77,7 +77,7 @@ public class PriorityQueueTTS: NSObject {
         while !queue.isEmpty {
             guard let item = queue.extractMax() else { break }
             guard let completion = item.completion else { continue }
-            completion(item, nil, .Canceled)
+            completion(item, item.token, .Canceled)
         }
     }
     
@@ -110,7 +110,7 @@ public class PriorityQueueTTS: NSObject {
         guard !queue.isEmpty else { return }
         guard let entry = queue.extractMax() else { return }
         guard Date().timeIntervalSince1970 < entry.expire_at else {
-            entry.completion?( entry, nil, .Canceled )
+            entry.completion?( entry, entry.token, .Canceled )
             return
         }
         processingEntry = entry
@@ -167,6 +167,7 @@ public class PriorityQueueTTS: NSObject {
                     speakingRange = NSRange(location:0, length:utterance.speechString.count)
                 }
                 
+                let token = entry.token
                 entry.finish(with: speakingRange)
                 if entry.is_completed() {
                     if let delegate = self.delegate {
@@ -177,9 +178,9 @@ public class PriorityQueueTTS: NSObject {
                 }
                 if let completion = entry.completion {
                     if entry.is_completed() {
-                        completion(entry, utterance, .Completed)
+                        completion(entry, token, .Completed)
                     } else {
-                        completion(entry, utterance, .Paused)
+                        completion(entry, token, .Paused)
                     }
                 }
             }

--- a/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
+++ b/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
@@ -51,7 +51,7 @@ public class PriorityQueueTTS: NSObject {
         
         if let currentItem = processingEntry,
            currentItem.priority < entry.priority {
-            tts.stopSpeaking(at: .immediate)
+            tts.stopSpeaking(at: cancelBoundary)
         }
         queue.insert(entry)
     }
@@ -91,6 +91,12 @@ public class PriorityQueueTTS: NSObject {
                 return true
             }
             return false
+        }
+    }
+    
+    public func stopSpeaking( at boundary: AVSpeechBoundary = .immediate ) {
+        if tts.isSpeaking {
+            tts.stopSpeaking(at: boundary)
         }
     }
     

--- a/Sources/PriorityQueueTTS/QueueEntry.swift
+++ b/Sources/PriorityQueueTTS/QueueEntry.swift
@@ -58,7 +58,7 @@ public class QueueEntry: Comparable, Hashable {
     public let volume :Float
     public let speechRate :Float
     public let voice :AVSpeechSynthesisVoice?
-    public var completion: ((_ entry: QueueEntry, _ utterance: AVSpeechUtterance?, _ reason: CompletionReason) -> Void)?
+    public var completion: ((_ entry: QueueEntry, _ token: Token?, _ reason: CompletionReason) -> Void)?
     public func is_completed() -> Bool {
         return status == .completed
     }
@@ -83,7 +83,7 @@ public class QueueEntry: Comparable, Hashable {
         volume :Float,
         speechRate :Float,
         voice :AVSpeechSynthesisVoice?,
-        completion: ((_: QueueEntry, _: AVSpeechUtterance?, _: CompletionReason) -> Void)?
+        completion: ((_: QueueEntry, _: Token?, _: CompletionReason) -> Void)?
     ) {
         if let token = token {
             self._tokens = [token]
@@ -104,7 +104,7 @@ public class QueueEntry: Comparable, Hashable {
         priority: SpeechPriority = .Normal,
         timeout_sec: TimeInterval = 10.0,
         tag: Tag = .Default,
-        completion: ((_ entry: QueueEntry, _ utteracne: AVSpeechUtterance?, _ reason: CompletionReason) -> Void)? = nil
+        completion: ((_ entry: QueueEntry, _ token: Token?, _ reason: CompletionReason) -> Void)? = nil
     ) {
         self.init(token: Token.Pause(pause), priority: priority, timeout_sec: timeout_sec, tag: tag, volume: 0, speechRate: 0, voice: nil, completion: completion)
     }
@@ -117,7 +117,7 @@ public class QueueEntry: Comparable, Hashable {
         volume :Float = 1.0,
         speechRate :Float = 0.5,
         voice :AVSpeechSynthesisVoice? = nil,
-        completion: ((_ entry: QueueEntry, _ utteracne: AVSpeechUtterance?, _ reason: CompletionReason) -> Void)? = nil
+        completion: ((_ entry: QueueEntry, _ token: Token?, _ reason: CompletionReason) -> Void)? = nil
     ) {
         self.init(token: Token.Text(text), priority: priority, timeout_sec: timeout_sec, tag: tag, volume: volume, speechRate: speechRate, voice: voice, completion: completion)
     }

--- a/Sources/PriorityQueueTTS/Token.swift
+++ b/Sources/PriorityQueueTTS/Token.swift
@@ -33,14 +33,16 @@ public class Token {
     public var pause: Int?
     public var readingRange: NSRange? {
         didSet {
-            if let newValue = readingRange {
+            if let newValue = absoluteReadingRange {
                 bufferedRange.push(newValue)
             }
         }
     }
     public var bufferedRange = BufferedRange()
-    
-    
+    public var absoluteReadingRange: NSRange? {
+        return readingRange?.shift(processedRange?.nextLocation ?? 0)
+    }
+
     public var spokenText: String? {
         get {
             if let text = text {
@@ -159,6 +161,7 @@ public class Token {
             temp = self.processedRange
             temp?.append(range: range)
         }
+        bufferedRange.clearHistory()
         if let range = temp,
            let newText = text.substring(after: range) {
             finished = newText.count == 0
@@ -218,5 +221,9 @@ public struct BufferedRange {
             let top = history.removeFirst()
             total -= top.length
         }
+    }
+    
+    public mutating func clearHistory() {
+        history.removeAll()
     }
 }

--- a/Sources/PriorityQueueTTS/TokenizerEntry.swift
+++ b/Sources/PriorityQueueTTS/TokenizerEntry.swift
@@ -35,7 +35,7 @@ public class TokenizerEntry: QueueEntry {
     private var cursor: Int
     private var startIndex: String.Index
     private var closed: Bool
-    private var _completion: ((_: QueueEntry, _: AVSpeechUtterance?, _: CompletionReason) -> Void)? = nil
+    private var _completion: ((_: QueueEntry, _: Token?, _: CompletionReason) -> Void)? = nil
 
     public init(
         separators: [String],
@@ -45,7 +45,7 @@ public class TokenizerEntry: QueueEntry {
         volume :Float = 1.0,
         speechRate :Float = 0.5,
         voice :AVSpeechSynthesisVoice? = nil,
-        completion: ((_: QueueEntry, _: AVSpeechUtterance?, _: CompletionReason) -> Void)? = nil
+        completion: ((_: QueueEntry, _: Token?, _: CompletionReason) -> Void)? = nil
     ) {
         self.separators = separators
         self.separatorCount = 0
@@ -54,7 +54,7 @@ public class TokenizerEntry: QueueEntry {
         self.closed = false
         self._completion = completion
         super.init(token: nil, priority: priority, timeout_sec: timeout_sec, tag: tag, volume: volume, speechRate: speechRate, voice: voice, completion: nil)
-        self.completion = { entry, utterance, reason in
+        self.completion = { entry, token, reason in
             switch(reason) {
             case .Completed:
                 self.tokenIndex += 1
@@ -63,7 +63,7 @@ public class TokenizerEntry: QueueEntry {
                 break
             }
             guard let _completion = self._completion else { return }
-            _completion(entry, utterance, reason)
+            _completion(entry, token, reason)
         }
     }
 

--- a/Tests/PriorityQueueTTSTests/PriorityQueueTTSTests.swift
+++ b/Tests/PriorityQueueTTSTests/PriorityQueueTTSTests.swift
@@ -1300,6 +1300,37 @@ final class PriorityQueueTTSTests: XCTestCase {
         tts.start()
         waitForExpectations(timeout: 30, handler: nil)
     }
+    
+    
+    func test_28_stop_speaking() throws {
+        let expectation = self.expectation(description: "Wait for 30 seconds")
+        let tts = PriorityQueueTTS()
+        var step = 0
+        tts.append(entry: QueueEntry(text: "this is first message.", priority: .Required) { item, token, reason in
+            switch(reason) {
+            case .Paused:
+                XCTAssertEqual( 0, step.pass() )
+            case .Completed:
+                XCTAssertEqual( 1, step.pass() )
+            case .Canceled:
+                XCTFail()
+            }
+        })
+        tts.append(entry: QueueEntry(text: "this is second message.", priority: .Normal) { item, token, reason in
+            guard reason == .Completed
+                else { XCTFail(); return }
+            XCTAssertEqual( 2, step.pass() )
+            expectation.fulfill()
+        })
+        
+        tts.start()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            tts.stopSpeaking(at: .immediate)
+        }
+        
+        waitForExpectations(timeout: 30, handler: nil)
+    }
 }
 
 

--- a/Tests/PriorityQueueTTSTests/PriorityQueueTTSTests.swift
+++ b/Tests/PriorityQueueTTSTests/PriorityQueueTTSTests.swift
@@ -38,16 +38,16 @@ final class PriorityQueueTTSTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for 10 seconds")
         let tts = PriorityQueueTTS()
         var count = 0
-        tts.append(entry: QueueEntry(text: "Hello1") { item, utterance, canceld in
+        tts.append(entry: QueueEntry(text: "Hello1") { item, token, canceld in
             XCTAssertEqual(count, 1)
             count += 1
         })
-        tts.append(entry: QueueEntry(text: "Hello2") { item, utterance, canceld in
+        tts.append(entry: QueueEntry(text: "Hello2") { item, token, canceld in
             XCTAssertEqual(count, 2)
             count += 1
             expectation.fulfill()
         })
-        tts.append(entry: QueueEntry(text: "Hello3", priority: .High) { item, utterance, canceld in
+        tts.append(entry: QueueEntry(text: "Hello3", priority: .High) { item, token, canceld in
             XCTAssertEqual(count, 0)
             count += 1
         })
@@ -65,7 +65,7 @@ final class PriorityQueueTTSTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for 30 seconds")
         let tts = PriorityQueueTTS()
         var count = 0
-        tts.append(entry: QueueEntry(text: sample, timeout_sec: 30.0) { item, utterance, reason in
+        tts.append(entry: QueueEntry(text: sample, timeout_sec: 30.0) { item, token, reason in
             switch(reason) {
             case .Paused:
                 XCTAssertEqual(self.sample, item.token?.text)
@@ -86,7 +86,7 @@ final class PriorityQueueTTSTests: XCTestCase {
             }
         })
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-            tts.append(entry: QueueEntry(text: "High Priority Message", priority: .High, timeout_sec: 1) { item, utterance, reason in
+            tts.append(entry: QueueEntry(text: "High Priority Message", priority: .High, timeout_sec: 1) { item, token, reason in
                 XCTAssertEqual(count, 1)
                 count += 1
             })
@@ -105,7 +105,7 @@ final class PriorityQueueTTSTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for 30 seconds")
         let tts = PriorityQueueTTS()
         var count = 0
-        tts.append(entry: QueueEntry(text: sample, timeout_sec: 30) { item, utterance, reason in
+        tts.append(entry: QueueEntry(text: sample, timeout_sec: 30) { item, token, reason in
             switch(reason) {
             case .Paused:
                 XCTAssertTrue(false)
@@ -121,7 +121,7 @@ final class PriorityQueueTTSTests: XCTestCase {
             }
         })
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-            tts.append(entry: QueueEntry(text: "Normal Priority Message", priority: .Normal, timeout_sec: 15) { item, utterance, reason in
+            tts.append(entry: QueueEntry(text: "Normal Priority Message", priority: .Normal, timeout_sec: 15) { item, token, reason in
                 XCTAssertEqual(count, 1)
                 count += 1
                 expectation.fulfill()
@@ -142,18 +142,18 @@ final class PriorityQueueTTSTests: XCTestCase {
         let tts = PriorityQueueTTS()
         var count = 0
         var start: TimeInterval = 0
-        tts.append(entry: QueueEntry(text: "Hello1", timeout_sec: 10) { item, utterance, reason in
+        tts.append(entry: QueueEntry(text: "Hello1", timeout_sec: 10) { item, token, reason in
             XCTAssertEqual(count, 0)
             count += 1
             start = Date().timeIntervalSince1970
         })
-        tts.append(entry: QueueEntry(pause: 10, timeout_sec: 10) { item, utterance, reason in
+        tts.append(entry: QueueEntry(pause: 10, timeout_sec: 10) { item, token, reason in
             XCTAssertEqual(count, 1)
             count += 1
             let end = Date().timeIntervalSince1970
             XCTAssertLessThan(abs((end - start) - 1.0), 0.2)
         })
-        tts.append(entry: QueueEntry(text: "Hello2", timeout_sec: 10) { item, utterance, reason in
+        tts.append(entry: QueueEntry(text: "Hello2", timeout_sec: 10) { item, token, reason in
             XCTAssertEqual(count, 2)
             count += 1
             expectation.fulfill()
@@ -175,7 +175,7 @@ final class PriorityQueueTTSTests: XCTestCase {
         let tts = PriorityQueueTTS()
         var count = 0
         var start: TimeInterval = 0
-        tts.append(entry: QueueEntry(text: sample, timeout_sec: 30) { item, utterance, reason in
+        tts.append(entry: QueueEntry(text: sample, timeout_sec: 30) { item, token, reason in
             switch(reason) {
             case .Paused:
                 XCTAssertEqual(self.sample, item.token?.text)
@@ -183,8 +183,8 @@ final class PriorityQueueTTSTests: XCTestCase {
                 count += 1
                 break
             case .Completed:
-                if let textCount = utterance?.speechString.count {
-                    XCTAssertLessThan(textCount, self.sample.count)
+                if let textCount = token?.text?.count {
+                    XCTAssertLessThanOrEqual(textCount, self.sample.count)
                 }
                 XCTAssertEqual(count, 4)
                 count += 1
@@ -196,18 +196,18 @@ final class PriorityQueueTTSTests: XCTestCase {
             }
         })
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-            tts.append(entry: QueueEntry(text: "High Priority", priority: .High, timeout_sec: 1) { item, utterance, reason in
+            tts.append(entry: QueueEntry(text: "High Priority", priority: .High, timeout_sec: 1) { item, token, reason in
                 XCTAssertEqual(count, 1)
                 count += 1
                 start = Date().timeIntervalSince1970
             })
-            tts.append(entry: QueueEntry(pause: 5, priority: .High, timeout_sec: 3) { item, utterance, reason in
+            tts.append(entry: QueueEntry(pause: 5, priority: .High, timeout_sec: 3) { item, token, reason in
                 XCTAssertEqual(count, 2)
                 count += 1
                 let end = Date().timeIntervalSince1970
                 XCTAssertLessThan(abs((end - start) - 0.5), 0.1)
             })
-            tts.append(entry: QueueEntry(text: "Message", priority: .High, timeout_sec: 5) { item, utterance, reason in
+            tts.append(entry: QueueEntry(text: "Message", priority: .High, timeout_sec: 5) { item, token, reason in
                 XCTAssertEqual(count, 3)
                 count += 1
             })
@@ -229,7 +229,7 @@ final class PriorityQueueTTSTests: XCTestCase {
         let tts = PriorityQueueTTS()
         var count = 0
         var start: TimeInterval = 0
-        tts.append(entry: QueueEntry(text: sample, timeout_sec: 30) { item, utterance, reason in
+        tts.append(entry: QueueEntry(text: sample, timeout_sec: 30) { item, token, reason in
             switch(reason) {
             case .Paused:
                 XCTAssertTrue(false)
@@ -245,18 +245,18 @@ final class PriorityQueueTTSTests: XCTestCase {
             }
         })
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-            tts.append(entry: QueueEntry(text: "Normal Priority", priority: .Normal, timeout_sec: 15) { item, utterance, reason in
+            tts.append(entry: QueueEntry(text: "Normal Priority", priority: .Normal, timeout_sec: 15) { item, token, reason in
                 XCTAssertEqual(count, 1)
                 count += 1
                 start = Date().timeIntervalSince1970
             })
-            tts.append(entry: QueueEntry(pause: 5, priority: .Normal, timeout_sec: 15) { item, utterance, reason in
+            tts.append(entry: QueueEntry(pause: 5, priority: .Normal, timeout_sec: 15) { item, token, reason in
                 XCTAssertEqual(count, 2)
                 count += 1
                 let end = Date().timeIntervalSince1970
                 XCTAssertLessThan(abs((end - start) - 0.5), 0.1)
             })
-            tts.append(entry: QueueEntry(text: "Message", priority: .Normal, timeout_sec: 15) { item, utterance, reason in
+            tts.append(entry: QueueEntry(text: "Message", priority: .Normal, timeout_sec: 15) { item, token, reason in
                 XCTAssertEqual(count, 3)
                 count += 1
                 expectation.fulfill()
@@ -299,7 +299,7 @@ final class PriorityQueueTTSTests: XCTestCase {
         let delegate = Delegate()
         delegate.expectation = expectation
         tts.delegate = delegate
-        tts.append(entry: QueueEntry(text: sample, timeout_sec: 30) { item, utterance, reason in
+        tts.append(entry: QueueEntry(text: sample, timeout_sec: 30) { item, token, reason in
         })
         tts.start()
         waitForExpectations(timeout: 10, handler: nil)
@@ -336,7 +336,7 @@ final class PriorityQueueTTSTests: XCTestCase {
         let delegate = Delegate()
         delegate.expectation = expectation
         tts.delegate = delegate
-        tts.append(entry: QueueEntry(text: sample, timeout_sec: 30) { item, utterance, reason in
+        tts.append(entry: QueueEntry(text: sample, timeout_sec: 30) { item, token, reason in
         })
         tts.start()
         waitForExpectations(timeout: 10, handler: nil)
@@ -374,14 +374,14 @@ final class PriorityQueueTTSTests: XCTestCase {
         }
         let delegate = Delegate()
         tts.delegate = delegate
-        tts.append(entry: QueueEntry(text: sample, timeout_sec: 30) { item, utterance, reason in
+        tts.append(entry: QueueEntry(text: sample, timeout_sec: 30) { item, token, reason in
             if reason == .Completed {
                 expectation.fulfill()
             }
         })
         tts.start()
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-            tts.append(entry: QueueEntry(text: "High Priority Message", priority: .High, timeout_sec: 1) { item, utterance, reason in
+            tts.append(entry: QueueEntry(text: "High Priority Message", priority: .High, timeout_sec: 1) { item, token, reason in
             })
         }
         waitForExpectations(timeout: 30, handler: nil)
@@ -1277,23 +1277,20 @@ final class PriorityQueueTTSTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for 30 seconds")
         let tts = PriorityQueueTTS()
         var step = 0
-        tts.append(entry: QueueEntry(text: "default voice speaking") { item, utterance, reason in
+        tts.append(entry: QueueEntry(text: "default voice speaking") { item, token, reason in
             guard reason == .Completed
                 else { XCTFail(); return }
             XCTAssertEqual( 0, step.pass() )
         })
         let vol :Float = 0.3
         let rate :Float = 0.1
-        tts.append(entry: QueueEntry(text: "Fred speaking", volume:vol, speechRate:rate, voice: fredVoice) { item, utterance, reason in
+        tts.append(entry: QueueEntry(text: "Fred speaking", volume:vol, speechRate:rate, voice: fredVoice) { item, token, reason in
             guard reason == .Completed
                 else { XCTFail(); return }
             
             XCTAssertEqual( 1, step.pass() )
-            XCTAssertEqual( fredVoice, utterance?.voice )
-            XCTAssertEqual( vol, utterance?.volume )
-            XCTAssertEqual( rate, utterance?.rate )
         })
-        tts.append(entry: QueueEntry(text: "default voice speaking") { item, utterance, reason in
+        tts.append(entry: QueueEntry(text: "default voice speaking") { item, token, reason in
             guard reason == .Completed
                 else { XCTFail(); return }
             XCTAssertEqual( 2, step.pass() )

--- a/Tests/PriorityQueueTTSTests/TokenizerEntryTests.swift
+++ b/Tests/PriorityQueueTTSTests/TokenizerEntryTests.swift
@@ -43,7 +43,7 @@ final class TokenizerEntryTests: XCTestCase {
     func test2_process_tokenizer_item() throws {
         let expectation = self.expectation(description: "Wait for 15 seconds")
         let tts = PriorityQueueTTS()
-        let item = TokenizerEntry(separators: ["."]) { entry, utterance, reason in
+        let item = TokenizerEntry(separators: ["."]) { entry, token, reason in
             if reason == .Completed {
                 expectation.fulfill()
             }
@@ -67,7 +67,7 @@ final class TokenizerEntryTests: XCTestCase {
     func test3_2_process_tokenizer_item() throws {
         let expectation = self.expectation(description: "Wait for 15 seconds")
         let tts = PriorityQueueTTS()
-        let item = TokenizerEntry(separators: ["."]) { entry, utterance, reason in
+        let item = TokenizerEntry(separators: ["."]) { entry, token, reason in
             if reason == .Completed {
                 expectation.fulfill()
             }
@@ -83,7 +83,7 @@ final class TokenizerEntryTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for 30 seconds")
         let tts = PriorityQueueTTS()
         var response = 0
-        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, utterance, reason in
+        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, token, reason in
             response += 1
             if (response == 4) {
                 expectation.fulfill()
@@ -111,7 +111,7 @@ final class TokenizerEntryTests: XCTestCase {
         let expectation = self.expectation(description: "Wait for 30 seconds")
         let tts = PriorityQueueTTS()
         var response = 0
-        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, utterance, reason in
+        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, token, reason in
             response += 1
             if (response == 7) {
                 expectation.fulfill()
@@ -164,7 +164,7 @@ final class TokenizerEntryTests: XCTestCase {
         }
         let delegate = Delegate()
         tts.delegate = delegate
-        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, utterance, reason in
+        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, token, reason in
             if reason == .Completed {
                 expectation.fulfill()
             }
@@ -207,7 +207,7 @@ final class TokenizerEntryTests: XCTestCase {
         }
         let delegate = Delegate()
         tts.delegate = delegate
-        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, utterance, reason in
+        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, token, reason in
             if reason == .Completed {
                 expectation.fulfill()
             }
@@ -247,7 +247,7 @@ final class TokenizerEntryTests: XCTestCase {
         }
         let delegate = Delegate()
         tts.delegate = delegate
-        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, utterance, reason in
+        let item = TokenizerEntry(separators: ["."], timeout_sec: 30) { entry, token, reason in
             if reason == .Completed {
                 expectation.fulfill()
             }
@@ -257,7 +257,7 @@ final class TokenizerEntryTests: XCTestCase {
         tts.append(entry: item)
         tts.start()
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-            tts.append(entry: QueueEntry(text: "High Priority Message", priority: .High, timeout_sec: 1) { item, utterance, reason in
+            tts.append(entry: QueueEntry(text: "High Priority Message", priority: .High, timeout_sec: 1) { item, token, reason in
             })
         }
         waitForExpectations(timeout: 15, handler: nil)
@@ -273,7 +273,7 @@ final class TokenizerEntryTests: XCTestCase {
         let tts = PriorityQueueTTS()
         var step : Int = 0;
 
-        let entry1 = TokenizerEntry(separators: ["."], tag: "A") { entry, utterance, reason in
+        let entry1 = TokenizerEntry(separators: ["."], tag: "A") { entry, token, reason in
             switch(reason) {
             case .Canceled:
                 XCTAssertEqual(0, step.pass())
@@ -290,7 +290,7 @@ final class TokenizerEntryTests: XCTestCase {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             // 2)  (TAG:"A", .Normal)
-            let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, utterance, reason in
+            let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, token, reason in
                 switch(reason) {
                 case .Paused:
                     XCTAssertEqual(1, step.pass())
@@ -320,7 +320,7 @@ final class TokenizerEntryTests: XCTestCase {
         let tts = PriorityQueueTTS()
         var step : Int = 0;
 
-        let entry1 = TokenizerEntry(separators: ["."], tag: "A") { entry, utterance, reason in
+        let entry1 = TokenizerEntry(separators: ["."], tag: "A") { entry, token, reason in
             switch(reason) {
             case .Canceled:
                 XCTAssertTrue( (0...1).contains(step.pass()) )
@@ -335,7 +335,7 @@ final class TokenizerEntryTests: XCTestCase {
         tts.append(entry: entry1)
         
         // 2) (TAG:"A", .Normal) // remove
-        let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, utterance, reason in
+        let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, token, reason in
             switch(reason) {
             case .Canceled:
                 XCTAssertTrue( (0...1).contains(step.pass()) )
@@ -353,7 +353,7 @@ final class TokenizerEntryTests: XCTestCase {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
             // 3)  (TAG:"A", .Normal)
-            let entry3 = TokenizerEntry(separators: ["."], tag: "A") { entry, utterance, reason in
+            let entry3 = TokenizerEntry(separators: ["."], tag: "A") { entry, token, reason in
                 switch(reason) {
                 case .Paused:
                     XCTAssertEqual(2, step.pass())
@@ -384,7 +384,7 @@ final class TokenizerEntryTests: XCTestCase {
         var step : Int = 0;
 
         // 1) (TAG:"Def", .Normal) // keep
-        let entry1 = TokenizerEntry(separators: ["."]) { entry, utterance, reason in
+        let entry1 = TokenizerEntry(separators: ["."]) { entry, token, reason in
             switch(reason) {
             case .Paused:
                 XCTAssertTrue( (0...2).contains(step.pass()) )
@@ -399,7 +399,7 @@ final class TokenizerEntryTests: XCTestCase {
         tts.append(entry: entry1)
         
         // 2) (TAG:"A", .Normal) // remove
-        let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, utterance, reason in
+        let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, token, reason in
             switch(reason) {
             case .Canceled:
                 XCTAssertTrue( (0...2).contains(step.pass()) )
@@ -415,7 +415,7 @@ final class TokenizerEntryTests: XCTestCase {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
             // 3)  (TAG:"A", .Normal)
-            let entry3 = TokenizerEntry(separators: ["."], tag: "A") { entry, utterance, reason in
+            let entry3 = TokenizerEntry(separators: ["."], tag: "A") { entry, token, reason in
                 switch(reason) {
                 case .Paused:
                     XCTAssertEqual(4, step.pass())
@@ -446,7 +446,7 @@ final class TokenizerEntryTests: XCTestCase {
         var step : Int = 0;
 
         // 1) (TAG:"Def", .High) // interrupt
-        let entry1 = TokenizerEntry(separators: ["."], priority: .High) { entry, utterance, reason in
+        let entry1 = TokenizerEntry(separators: ["."], priority: .High) { entry, token, reason in
             switch(reason) {
             case .Paused:
                 XCTAssertTrue( Set([0,1,4,5]).contains(step.pass()) )
@@ -462,7 +462,7 @@ final class TokenizerEntryTests: XCTestCase {
         tts.append(entry: entry1)
         
         // 2) (TAG:"A", .Normal) // remove
-        let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, utterance, reason in
+        let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, token, reason in
             switch(reason) {
             case .Canceled:
                 XCTAssertTrue( Set([0,1]).contains(step.pass()) )
@@ -478,7 +478,7 @@ final class TokenizerEntryTests: XCTestCase {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             // 3) (TAG:"A", .Required)
-            let entry3 = TokenizerEntry(separators: ["."], priority: .Required, tag: "A") { entry, utterance, reason in
+            let entry3 = TokenizerEntry(separators: ["."], priority: .Required, tag: "A") { entry, token, reason in
                 switch(reason) {
                 case .Paused:
                     XCTAssertEqual(2, step.pass())
@@ -510,7 +510,7 @@ final class TokenizerEntryTests: XCTestCase {
         var step : Int = 0;
 
         // 1. (Text TAG:"A") // stop-replace not closed
-        let entry1 = TokenizerEntry(separators: ["."], tag: "A") { entry, utterance, reason in
+        let entry1 = TokenizerEntry(separators: ["."], tag: "A") { entry, token, reason in
             switch(reason) {
             case .Canceled:
                 XCTAssertTrue( (0...1).contains(step.pass()) )
@@ -525,7 +525,7 @@ final class TokenizerEntryTests: XCTestCase {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             //  << 2. (Text TAG:"A")
-            let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, utterance, reason in
+            let entry2 = TokenizerEntry(separators: ["."], tag: "A") { entry, token, reason in
                 switch(reason) {
                 case .Paused:
                     XCTAssertTrue( (0...1).contains(step.pass()) )
@@ -568,7 +568,7 @@ final class TokenizerEntryTests: XCTestCase {
         var step : Int = 0;
 
         // 1. (Text .Normal) // interrupt -> timeout
-        let entry1 = TokenizerEntry(separators: ["."], priority: .Normal, timeout_sec: 4) { entry, utterance, reason in
+        let entry1 = TokenizerEntry(separators: ["."], priority: .Normal, timeout_sec: 4) { entry, token, reason in
             switch(reason) {
             case .Paused:
                 XCTAssertEqual(0, step.pass())
@@ -607,4 +607,51 @@ final class TokenizerEntryTests: XCTestCase {
 
         waitForExpectations(timeout: 30, handler: nil)
     }
+    
+    
+    
+    func test15_stop_speaking() throws {
+        let msg1 = "this is first message."
+        let msg2 = "this is second message."
+        let msg3 = "this is third message."
+        let msg4 = "this is fourth message."
+        
+        let expectation = self.expectation(description: "Wait for 30 seconds")
+        let tts = PriorityQueueTTS()
+        var step = 0
+        
+        let entry1 = TokenizerEntry(separators: ["."], priority: .Required, timeout_sec: 10) { entry, token, reason in
+            switch(reason) {
+            case .Paused:
+                XCTAssertTrue( (0...2).contains(step.pass()) ) // 3text + 1interrupt
+            case .Completed:
+                XCTAssertEqual(3, step.pass())
+            case .Canceled:
+                XCTFail()
+            }
+        }
+        try? entry1.append(text: msg1)
+        try? entry1.append(text: msg2)
+        try? entry1.append(text: msg3)
+        entry1.close()
+        tts.append(entry: entry1)
+        
+        let entry2 = TokenizerEntry(separators: ["."], priority: .Required, timeout_sec: 10) { entry, token, reason in
+            XCTAssertEqual(4, step.pass())
+            XCTAssertEqual(CompletionReason.Completed, reason)
+            expectation.fulfill()
+        }
+        try? entry2.append(text: msg4)
+        entry2.close()
+        tts.append(entry: entry2)
+        
+        tts.start()
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            tts.stopSpeaking(at: .immediate)
+        }
+        
+        waitForExpectations(timeout: 30, handler: nil)
+    }
+
 }


### PR DESCRIPTION
* （優先度が高いエントリが追加されるなどで）発話の割り込みが発生した場合、進捗コールバックのRangeが不正になる問題を修正
  * 割り込み後、発話再開した "部分文字列の" Range が報告されていた
    * Token に absoluteReadingRange を追加
  * 完了コールバックで、対象の utterance を報告していたが、割り込みがあった場合は utterance の対象が部分文字列となる為、意味が無かった。 → 処理した Token を返す様に修正した
* NavDeviceTTS で供給されていた、TTS の発話を止めるだけの処理に相当するAPI：stopSpeaking() を追加した （＋UT）