### PR TITLE
Fix/utterance attribute

### DIFF
--- a/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
+++ b/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
@@ -61,7 +61,7 @@ public class PriorityQueueTTS: NSObject {
 
     public func start() {
         dipatchQueue.async {
-            let timer = Timer(timeInterval: 0.01, repeats: true) { timer in
+            let timer = Timer(timeInterval: 0.1, repeats: true) { timer in
                 self.processQueue()
             }
             RunLoop.current.add(timer, forMode: .default)

--- a/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
+++ b/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
@@ -218,6 +218,10 @@ public class PriorityQueueTTS: NSObject {
     public var isPaused: Bool {
         return tts.isPaused
     }
+
+    public var priority: SpeechPriority? {
+        return processingEntry?.priority
+    }
 }
 
 extension PriorityQueueTTS: AVSpeechSynthesizerDelegate {

--- a/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
+++ b/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
@@ -206,6 +206,18 @@ public class PriorityQueueTTS: NSObject {
     public var isSpeaking : Bool {
         return tts.isSpeaking && !tts.isPaused
     }
+
+    public func toggleSpeakState() {
+        if tts.isPaused {
+            tts.continueSpeaking()
+        } else if tts.isSpeaking {
+            tts.pauseSpeaking(at: .immediate)
+        }
+    }
+
+    public var isPaused: Bool {
+        return tts.isPaused
+    }
 }
 
 extension PriorityQueueTTS: AVSpeechSynthesizerDelegate {

--- a/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
+++ b/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
@@ -77,11 +77,13 @@ public class PriorityQueueTTS: NSObject {
         if let processingEntry {
             stopProcessingImmediately( current:processingEntry, at:boundary )
         }
+        let brefore = queue.count
         while !queue.isEmpty {
             guard let item = queue.extractMax() else { break }
             guard let completion = item.completion else { continue }
             completion(item, item.token, .Canceled)
         }
+        NSLog("[TTS] cancel queue (\(brefore) -> \(queue.count)")
     }
     
     public func cancel( where filter: (QueueEntry) -> Bool, at boundary: AVSpeechBoundary = .immediate ) {
@@ -104,8 +106,10 @@ public class PriorityQueueTTS: NSObject {
     }
     
     private func stopProcessingImmediately( current: QueueEntry, at boundary: AVSpeechBoundary = .immediate ) {
+        NSLog("[TTS] stopProcessingImmediately...")
         current.mark_canceled()
         if tts.isSpeaking {
+            NSLog("[TTS] stopSpeaking")
             tts.stopSpeaking(at: boundary)
         }
         if let pausing {

--- a/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
+++ b/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
@@ -210,7 +210,7 @@ public class PriorityQueueTTS: NSObject {
     public func toggleSpeakState() {
         if tts.isPaused {
             tts.continueSpeaking()
-        } else if tts.isSpeaking {
+        } else if tts.isSpeaking, let currentItem = processingEntry, currentItem.priority < .Required {
             tts.pauseSpeaking(at: .immediate)
         }
     }

--- a/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
+++ b/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
@@ -31,6 +31,9 @@ public class PriorityQueueTTS: NSObject {
     public static var shared = PriorityQueueTTS()
 
     public var delegate: PriorityQueueTTSDelegate?
+    public var volume :Float = 1.0
+    public var speechRate :Float = 0.5
+    public var voice :AVSpeechSynthesisVoice? = nil
     private var queue: PriorityQueue<QueueEntry> = PriorityQueue<QueueEntry>()
     private var tts: AVSpeechSynthesizer
     private var processingEntry: QueueEntry?
@@ -130,9 +133,9 @@ public class PriorityQueueTTS: NSObject {
             case .Text:
                 NSLog("speak text:\(token), priority:\(entry.priority)")
                 if let utterance = token.utterance {
-                    utterance.volume = entry.volume
-                    utterance.rate = entry.speechRate;
-                    utterance.voice = entry.voice;
+                    utterance.volume = entry.volume ?? self.volume
+                    utterance.rate = entry.speechRate ?? self.speechRate
+                    utterance.voice = entry.voice ?? self.voice
                     tts.speak(utterance)
                 }
                 break

--- a/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
+++ b/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
@@ -207,11 +207,11 @@ public class PriorityQueueTTS: NSObject {
         return tts.isSpeaking && !tts.isPaused
     }
 
-    public func toggleSpeakState() {
+    public func toggleSpeakState(at boundary: AVSpeechBoundary = .immediate) {
         if tts.isPaused {
             tts.continueSpeaking()
         } else if tts.isSpeaking, let currentItem = processingEntry, currentItem.priority < .Required {
-            tts.pauseSpeaking(at: .immediate)
+            tts.pauseSpeaking(at: boundary)
         }
     }
 

--- a/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
+++ b/Sources/PriorityQueueTTS/PriorityQueueTTS.swift
@@ -236,6 +236,13 @@ extension PriorityQueueTTS: AVSpeechSynthesizerDelegate {
 
     public func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
         // NSLog("didFinish \(utterance.speechString)")
+        if let range = speakingRange {
+            let newLocation = range.location + range.length
+            if newLocation < utterance.speechString.count {
+                let newRange = NSRange(location: newLocation, length: utterance.speechString.count - newLocation)
+                speechSynthesizer(synthesizer, willSpeakRangeOfSpeechString: newRange, utterance: utterance)
+            }
+        }
         finish(utterance: utterance)
     }
 

--- a/Sources/PriorityQueueTTS/QueueEntry.swift
+++ b/Sources/PriorityQueueTTS/QueueEntry.swift
@@ -55,8 +55,8 @@ public class QueueEntry: Comparable, Hashable {
     public let created_time: TimeInterval
     public let expire_at: TimeInterval
     public let tag: Tag
-    public let volume :Float
-    public let speechRate :Float
+    public let volume :Float?
+    public let speechRate :Float?
     public let voice :AVSpeechSynthesisVoice?
     public var completion: ((_ entry: QueueEntry, _ token: Token?, _ reason: CompletionReason) -> Void)?
     public func is_completed() -> Bool {
@@ -80,8 +80,8 @@ public class QueueEntry: Comparable, Hashable {
         priority: SpeechPriority,
         timeout_sec: TimeInterval,
         tag: Tag,
-        volume :Float,
-        speechRate :Float,
+        volume :Float?,
+        speechRate :Float?,
         voice :AVSpeechSynthesisVoice?,
         completion: ((_: QueueEntry, _: Token?, _: CompletionReason) -> Void)?
     ) {
@@ -114,8 +114,8 @@ public class QueueEntry: Comparable, Hashable {
         priority: SpeechPriority = .Normal,
         timeout_sec: TimeInterval = 10.0,
         tag: Tag = .Default,
-        volume :Float = 1.0,
-        speechRate :Float = 0.5,
+        volume :Float? = nil,
+        speechRate :Float? = nil,
         voice :AVSpeechSynthesisVoice? = nil,
         completion: ((_ entry: QueueEntry, _ token: Token?, _ reason: CompletionReason) -> Void)? = nil
     ) {

--- a/Sources/PriorityQueueTTS/SpeechPriority.swift
+++ b/Sources/PriorityQueueTTS/SpeechPriority.swift
@@ -27,6 +27,7 @@ public enum SpeechPriority: Int8 {
 
     case Low = 10
     case Chat = 20
+    case Moderate = 25
     case Normal = 30
     case High = 60
     case Required = 90

--- a/Sources/PriorityQueueTTS/SpeechPriority.swift
+++ b/Sources/PriorityQueueTTS/SpeechPriority.swift
@@ -25,10 +25,11 @@ import Foundation
 public enum SpeechPriority: Int8 {
     public typealias RawValue = Int8
 
-    case Low = 0
-    case Normal = 1
-    case High = 2
-    case Required = 3
+    case Low = 10
+    case Chat = 20
+    case Normal = 30
+    case High = 40
+    case Required = 50
 }
 
 extension SpeechPriority: Comparable {

--- a/Sources/PriorityQueueTTS/SpeechPriority.swift
+++ b/Sources/PriorityQueueTTS/SpeechPriority.swift
@@ -28,8 +28,8 @@ public enum SpeechPriority: Int8 {
     case Low = 10
     case Chat = 20
     case Normal = 30
-    case High = 40
-    case Required = 50
+    case High = 60
+    case Required = 90
 }
 
 extension SpeechPriority: Comparable {

--- a/Sources/PriorityQueueTTS/TokenizerEntry.swift
+++ b/Sources/PriorityQueueTTS/TokenizerEntry.swift
@@ -42,8 +42,8 @@ public class TokenizerEntry: QueueEntry {
         priority: SpeechPriority = .Normal,
         timeout_sec: TimeInterval = 10.0,
         tag: Tag = .Default,
-        volume :Float = 1.0,
-        speechRate :Float = 0.5,
+        volume :Float? = nil,
+        speechRate :Float? = nil,
         voice :AVSpeechSynthesisVoice? = nil,
         completion: ((_: QueueEntry, _: Token?, _: CompletionReason) -> Void)? = nil
     ) {


### PR DESCRIPTION
宮崎さんから「読上げスピードを変えても、割り込まれて後回しにされたエントリーのスピードが変わらない」という指摘があり修正しました。

* 修正前はエントリーに「読上げスピード」「Voice」「Volume」を指定してた為、発生
  * PriorityQueueTTS に上記属性を設定できる様に修正
  * 既存のエントリー指定はそのままにしています
    * エントリーに指定があった場合はそちらを優先します
      *  → 特定のエントリーは音声を変える、などのユースケースを想定

また、キューを循環するタイミングを 「0.01,」から「0.1」に変更しています。
*  ← 「こんにちわスーツケース」の発話をタグ指定しても除去されなかった問題の対応